### PR TITLE
tests: /ping handler test cases

### DIFF
--- a/tests/ping/README.md
+++ b/tests/ping/README.md
@@ -1,0 +1,43 @@
+# /ping Handler Tests
+
+The `/ping` handler echoes `params` back as `result`. It's the simplest handler, used to validate the basic harness.
+
+## Test Cases
+
+| Test | Input | Expected Result |
+|------|-------|-----------------|
+| `success-empty` | `{}` | `{}` |
+| `success-object` | `{echo: "hello", count: 42}` | same |
+| `success-nested` | `{user: {name, prefs: {theme}}}` | same |
+| `success-array` | `{items: [1,2,3], tags: ["a","b"]}` | same |
+| `success-null` | `null` | `null` |
+| `success-boolean` | `{active: true, deleted: false}` | same |
+| `success-unicode` | emoji, japanese, rtl, escapes | same |
+| `success-empty-key` | `{"": "empty key"}` | same |
+| `error-invalid-json` | `{not valid json` | error response |
+
+## Result Envelope
+
+All responses follow the standard envelope:
+
+```json
+{
+  "status": "success" | "error",
+  "result": <echoed params> | null,
+  "errors": null | { "params": [...] },
+  "meta": {
+    "path": "/ping",
+    "timestamp": "<iso8601>",
+    "duration_ms": <number>
+  }
+}
+```
+
+## REPL Prompt
+
+🧠>
+
+## Reviewed By
+
+- **Claude** - Designed initial test cases
+- **Gemini** - Antagonist review (suggested unicode, boolean, empty-key, invalid-json)


### PR DESCRIPTION
## Summary

Test cases for the `/ping` handler - the foundational echo endpoint that validates the basic harness.

## Test Cases (9 total)

| Test | Input | Expected |
|------|-------|----------|
| `success-empty` | `{}` | `{}` |
| `success-object` | `{echo, count}` | same |
| `success-nested` | nested objects | same |
| `success-array` | arrays | same |
| `success-null` | `null` | `null` |
| `success-boolean` | `{active: true}` | same |
| `success-unicode` | emoji, japanese, rtl | same |
| `success-empty-key` | `{"": "val"}` | same |
| `error-invalid-json` | malformed | error response |

## REPL Prompt

🧠>

## Reviewed By

- **Claude** - Designed tests
- **Gemini** - Antagonist review (suggested unicode, boolean, empty-key, invalid-json cases)

## Questions for Review

1. Are 9 test cases sufficient for `/ping`?
2. Any edge cases missing?
3. Is the error structure correct for invalid JSON?

## Test Boundary

These tests have `skip` marker. **Awaiting human approval before implementation.**

---

🤖 Generated with [Claude Code](https://claude.ai/code)