### PR TITLE
MCP remember/recall/forget: high-level agent memory tools (#35)

### DIFF
--- a/dna/product/ROADMAP.md
+++ b/dna/product/ROADMAP.md
@@ -31,10 +31,6 @@ If stuck → Human checkpoint     ← Cannot make tests pass
 
 **Goal:** Transform brane into a deterministic subjective memory layer for AI agents, exposed via MCP.
 
-### In Progress
-
-- [ ] `034-episodic-memory` — Episodes relation + CRUD + semantic search ([#34](https://github.com/ahoward/brane/issues/34), PR [#57](https://github.com/ahoward/brane/pull/57))
-
 ### Next — Agent Memory Critical Path
 
 - [ ] `035-mcp-remember-recall` — MCP tools: remember and recall for episodic memory ([#35](https://github.com/ahoward/brane/issues/35))
@@ -78,6 +74,7 @@ If stuck → Human checkpoint     ← Cannot make tests pass
 
 | Feature | PR | Date |
 |---------|-----|------|
+| `034-episodic-memory` | #57 | 2026-03-26 |
 | `053-fuzzy-dedup` | #55 | 2026-03-26 |
 | `049-schema-migrations` | #56 | 2026-03-26 |
 | `034-extraction-pipeline` | #32 | 2026-03-06 |

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -215,6 +215,47 @@ const TOOLS: McpTool[] = [
       required: ["query"],
     },
   },
+  //
+  // High-level agent memory tools (remember/recall/forget)
+  //
+  {
+    name: "remember",
+    description: "Store a memory about something you observed, learned, or decided. Use this whenever you want to remember something for future conversations.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        observation: { type: "string", description: "What you observed, learned, or decided" },
+        context:     { type: "string", description: "What you were doing when you learned this" },
+        outcome:     { type: "string", description: "What happened as a result" },
+        tags:        { type: "array", items: { type: "string" }, description: "Labels to categorize this memory" },
+      },
+      required: ["observation"],
+    },
+  },
+  {
+    name: "recall",
+    description: "Search your memories for relevant past experiences. Use this when you want to remember something from a previous conversation or task.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "What you're trying to remember — describe the topic or situation" },
+        limit: { type: "number", description: "Max memories to return (default 5)" },
+        tag:   { type: "string", description: "Filter to memories with this tag" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "forget",
+    description: "Remove a memory that is no longer relevant or correct.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "number", description: "Episode ID to forget" },
+      },
+      required: ["id"],
+    },
+  },
 ]
 
 //
@@ -239,6 +280,16 @@ const TOOL_ROUTES: Record<string, string> = {
 }
 
 //
+// Max payload size for recall results (bytes). Prevents overflowing agent context windows.
+//
+const MAX_RECALL_PAYLOAD = 32 * 1024  // 32KB
+
+//
+// MCP client metadata (populated during initialize)
+//
+let mcp_agent_id = "unknown"
+
+//
 // State
 //
 
@@ -248,7 +299,13 @@ let initialized = false
 // Handle initialize
 //
 
-function handle_initialize(_params: Record<string, unknown>): unknown {
+function handle_initialize(params: Record<string, unknown>): unknown {
+  // Extract agent_id from client info
+  const client_info = params.clientInfo as { name?: string } | undefined
+  if (client_info?.name) {
+    mcp_agent_id = client_info.name
+  }
+
   return {
     protocolVersion: MCP_VERSION,
     capabilities: { tools: {} },
@@ -265,16 +322,141 @@ function handle_tools_list(): unknown {
 }
 
 //
-// Handle tools/call — dispatch to sys.call
+// Custom tool handlers for high-level agent memory tools
+//
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>
+
+function truncate_payload(text: string, max_bytes: number): string {
+  const buf = Buffer.from(text, "utf8")
+  if (buf.length <= max_bytes) return text
+  // Slice raw bytes, avoiding partial UTF-8 sequences
+  const truncated = buf.subarray(0, max_bytes - 50)
+  // toString replaces partial trailing bytes with U+FFFD; strip those
+  return truncated.toString("utf8").replace(/\uFFFD+$/, "") + "\n...(truncated)"
+}
+
+const CUSTOM_HANDLERS: Record<string, ToolHandler> = {
+  //
+  // remember — create an episode with auto-populated agent_id
+  //
+  async remember(args) {
+    const episode_args = {
+      agent_id:    mcp_agent_id,
+      observation: args.observation,
+      context:     args.context ?? "",
+      outcome:     args.outcome ?? "",
+      tags:        args.tags ?? [],
+    }
+
+    const result = await sys.call("/mind/episodes/create", episode_args)
+
+    if (result.status === "error") {
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        isError: true,
+      }
+    }
+
+    const ep = result.result as Record<string, unknown>
+    const summary = `Remembered (id=${ep.id}): ${ep.observation}`
+    return {
+      content: [{ type: "text", text: summary }],
+      isError: false,
+    }
+  },
+
+  //
+  // recall — semantic search with payload truncation
+  //
+  async recall(args) {
+    const search_args: Record<string, unknown> = {
+      query: args.query,
+      limit: args.limit ?? 5,
+      // Default to current agent's memories; explicit agent_id overrides
+      agent_id: mcp_agent_id,
+    }
+
+    const result = await sys.call("/mind/episodes/search", search_args)
+
+    if (result.status === "error") {
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        isError: true,
+      }
+    }
+
+    const raw = (result.result as Record<string, unknown> | null) ?? {}
+    let matches = Array.isArray((raw as { matches?: unknown }).matches)
+      ? (raw as { matches: Record<string, unknown>[] }).matches
+      : []
+
+    // Post-filter by tag if specified
+    if (args.tag && typeof args.tag === "string") {
+      matches = matches.filter(m => {
+        const tags = m.tags as string[] | undefined
+        return tags && tags.includes(args.tag as string)
+      })
+    }
+
+    // Format for agent consumption — concise, readable
+    const memories = matches.map((m, i) => {
+      const parts = [`[${i + 1}] (id=${m.id}, score=${m.score})`]
+      parts.push(`  ${m.observation}`)
+      if (m.context) parts.push(`  context: ${m.context}`)
+      if (m.outcome) parts.push(`  outcome: ${m.outcome}`)
+      const tags = m.tags as string[]
+      if (tags && tags.length > 0) parts.push(`  tags: ${tags.join(", ")}`)
+      parts.push(`  when: ${m.timestamp}`)
+      return parts.join("\n")
+    })
+
+    const header = matches.length > 0
+      ? `Found ${matches.length} relevant memories:`
+      : "No relevant memories found."
+
+    let text = header + "\n\n" + memories.join("\n\n")
+    text = truncate_payload(text, MAX_RECALL_PAYLOAD)
+
+    return {
+      content: [{ type: "text", text }],
+      isError: false,
+    }
+  },
+
+  //
+  // forget — delete an episode by ID
+  //
+  async forget(args) {
+    const result = await sys.call("/mind/episodes/delete", { id: args.id })
+
+    if (result.status === "error") {
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        isError: true,
+      }
+    }
+
+    return {
+      content: [{ type: "text", text: `Forgot memory id=${args.id}` }],
+      isError: false,
+    }
+  },
+}
+
+//
+// Handle tools/call — dispatch to custom handlers or sys.call
 //
 
 async function handle_tools_call(params: Record<string, unknown>): Promise<unknown> {
   const name = String(params.name ?? "")
   const args = (params.arguments ?? {}) as Record<string, unknown>
 
-  // Validate tool exists
+  // Validate tool exists (check both route map and custom handlers)
   const route = TOOL_ROUTES[name]
-  if (!route) {
+  const custom = CUSTOM_HANDLERS[name]
+
+  if (!route && !custom) {
     const available = TOOLS.map(t => t.name).join(", ")
     return {
       content: [{ type: "text", text: `unknown tool: ${name}. Available: ${available}` }],
@@ -296,9 +478,13 @@ async function handle_tools_call(params: Record<string, unknown>): Promise<unkno
     }
   }
 
-  // Dispatch to sys.call
+  // Use custom handler if available, otherwise dispatch via route
   try {
-    const result = await sys.call(route, args)
+    if (custom) {
+      return await custom(args)
+    }
+
+    const result = await sys.call(route!, args)
     const text = JSON.stringify(result, null, 2)
 
     return {

--- a/try/mcp-remember-spike.sh
+++ b/try/mcp-remember-spike.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+
+#
+# mcp-remember-spike.sh — whitebox spike for MCP remember/recall/forget (#35)
+#
+# Tests the high-level agent memory tools via MCP JSON-RPC protocol.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BRANE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  ✓ $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  ✗ $1"
+  echo "    $2"
+}
+
+# Send a JSON-RPC request to the MCP server and capture the response
+mcp_call() {
+  local request="$1"
+  echo "$request" | (cd "$WORK" && BRANE_EMBED_MOCK=1 bun run "$BRANE_DIR/src/cli.ts" mcp 2>/dev/null) | head -1
+}
+
+# Send multiple JSON-RPC requests (newline-separated) and get responses
+mcp_session() {
+  local requests="$1"
+  echo "$requests" | (cd "$WORK" && BRANE_EMBED_MOCK=1 bun run "$BRANE_DIR/src/cli.ts" mcp 2>/dev/null)
+}
+
+# -------------------------------------------------------------------
+echo "=== Setup ==="
+# -------------------------------------------------------------------
+
+WORK=$(mktemp -d)
+echo "  workdir: $WORK"
+
+# Init brane in workdir
+cd "$BRANE_DIR"
+(cd "$WORK" && BRANE_EMBED_MOCK=1 bun run "$BRANE_DIR/src/cli.ts" /body/init) > /dev/null 2>&1
+(cd "$WORK" && BRANE_EMBED_MOCK=1 bun run "$BRANE_DIR/src/cli.ts" /mind/init) > /dev/null 2>&1
+
+# -------------------------------------------------------------------
+echo ""
+echo "=== MCP Initialize ==="
+# -------------------------------------------------------------------
+
+# Initialize + notification in one session
+INIT_RESP=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"claude-code","version":"1.0.0"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}')
+
+INIT_STATUS=$(echo "$INIT_RESP" | head -1 | jq -r '.result.serverInfo.name // empty')
+if [ "$INIT_STATUS" = "brane" ]; then
+  pass "MCP initialize"
+else
+  fail "MCP initialize" "got: $(echo "$INIT_RESP" | head -1 | head -c 200)"
+fi
+
+# -------------------------------------------------------------------
+echo ""
+echo "=== Remember ==="
+# -------------------------------------------------------------------
+
+# Remember something
+REMEMBER_RESP=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"claude-code"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"remember","arguments":{"observation":"User prefers dark mode in all editors","context":"setting up workspace","tags":["preference","ui"]}}}')
+
+REMEMBER_TEXT=$(echo "$REMEMBER_RESP" | tail -1 | jq -r '.result.content[0].text // empty')
+if echo "$REMEMBER_TEXT" | grep -q "Remembered"; then
+  pass "remember returns confirmation"
+else
+  fail "remember" "expected 'Remembered' in: $REMEMBER_TEXT"
+fi
+
+# Remember a second thing
+REMEMBER2_RESP=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"claude-code"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"remember","arguments":{"observation":"Running tests with --parallel causes flaky failures","context":"debugging CI","outcome":"switched to sequential","tags":["bug","testing"]}}}')
+
+REMEMBER2_TEXT=$(echo "$REMEMBER2_RESP" | tail -1 | jq -r '.result.content[0].text // empty')
+if echo "$REMEMBER2_TEXT" | grep -q "Remembered"; then
+  pass "remember second memory"
+else
+  fail "remember second" "$REMEMBER2_TEXT"
+fi
+
+# Remember with missing observation -> error
+REMEMBER_ERR=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"remember","arguments":{}}}')
+
+REMEMBER_ERR_FLAG=$(echo "$REMEMBER_ERR" | tail -1 | jq -r '.result.isError // empty')
+if [ "$REMEMBER_ERR_FLAG" = "true" ]; then
+  pass "remember missing observation -> error"
+else
+  fail "remember error" "expected isError=true"
+fi
+
+# -------------------------------------------------------------------
+echo ""
+echo "=== Recall ==="
+# -------------------------------------------------------------------
+
+# Recall memories about dark mode
+RECALL_RESP=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"claude-code"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"recall","arguments":{"query":"editor preferences dark mode"}}}')
+
+RECALL_TEXT=$(echo "$RECALL_RESP" | tail -1 | jq -r '.result.content[0].text // empty')
+if echo "$RECALL_TEXT" | grep -q "relevant memories"; then
+  pass "recall returns memories"
+else
+  fail "recall" "expected 'relevant memories' in: $(echo "$RECALL_TEXT" | head -c 200)"
+fi
+
+if echo "$RECALL_TEXT" | grep -q "dark mode"; then
+  pass "recall finds dark mode memory"
+else
+  fail "recall content" "expected 'dark mode' in results"
+fi
+
+# Recall with tag filter
+RECALL_TAG=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"claude-code"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"recall","arguments":{"query":"testing","tag":"bug"}}}')
+
+RECALL_TAG_TEXT=$(echo "$RECALL_TAG" | tail -1 | jq -r '.result.content[0].text // empty')
+if echo "$RECALL_TAG_TEXT" | grep -q "flaky\|parallel"; then
+  pass "recall with tag filter works"
+else
+  fail "recall tag filter" "expected testing memory in: $(echo "$RECALL_TAG_TEXT" | head -c 200)"
+fi
+
+# Recall with missing query -> error
+RECALL_ERR=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"recall","arguments":{}}}')
+
+RECALL_ERR_FLAG=$(echo "$RECALL_ERR" | tail -1 | jq -r '.result.isError // empty')
+if [ "$RECALL_ERR_FLAG" = "true" ]; then
+  pass "recall missing query -> error"
+else
+  fail "recall error" "expected isError=true"
+fi
+
+# -------------------------------------------------------------------
+echo ""
+echo "=== Forget ==="
+# -------------------------------------------------------------------
+
+# Forget first memory (id=1)
+FORGET_RESP=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"claude-code"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"forget","arguments":{"id":1}}}')
+
+FORGET_TEXT=$(echo "$FORGET_RESP" | tail -1 | jq -r '.result.content[0].text // empty')
+if echo "$FORGET_TEXT" | grep -q "Forgot"; then
+  pass "forget returns confirmation"
+else
+  fail "forget" "expected 'Forgot' in: $FORGET_TEXT"
+fi
+
+# Forget non-existent -> error
+FORGET_ERR=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"forget","arguments":{"id":9999}}}')
+
+FORGET_ERR_FLAG=$(echo "$FORGET_ERR" | tail -1 | jq -r '.result.isError // empty')
+if [ "$FORGET_ERR_FLAG" = "true" ]; then
+  pass "forget non-existent -> error"
+else
+  fail "forget error" "expected isError=true"
+fi
+
+# -------------------------------------------------------------------
+echo ""
+echo "=== Tools List ==="
+# -------------------------------------------------------------------
+
+# Verify remember/recall/forget appear in tools list
+TOOLS_RESP=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/list"}')
+
+TOOLS_LIST=$(echo "$TOOLS_RESP" | tail -1 | jq -r '.result.tools[].name' 2>/dev/null | tr '\n' ' ')
+for tool in remember recall forget; do
+  if echo "$TOOLS_LIST" | grep -q "$tool"; then
+    pass "$tool in tools list"
+  else
+    fail "$tool in tools list" "not found in: $TOOLS_LIST"
+  fi
+done
+
+# -------------------------------------------------------------------
+echo ""
+echo "=== Agent ID Auto-Population ==="
+# -------------------------------------------------------------------
+
+# Create a memory and verify agent_id was set from client info
+EP_RESP=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"my-custom-agent"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"remember","arguments":{"observation":"agent id test"}}}')
+
+# Verify via episodes_list that agent_id is "my-custom-agent"
+EPISODES_RESP=$(mcp_session '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"episodes_list","arguments":{"agent_id":"my-custom-agent"}}}')
+
+EP_LIST_TEXT=$(echo "$EPISODES_RESP" | tail -1 | jq -r '.result.content[0].text // empty')
+if echo "$EP_LIST_TEXT" | grep -q "my-custom-agent"; then
+  pass "agent_id auto-populated from MCP client info"
+else
+  fail "agent_id auto-population" "expected 'my-custom-agent' in: $(echo "$EP_LIST_TEXT" | head -c 200)"
+fi
+
+# -------------------------------------------------------------------
+echo ""
+echo "=== Results ==="
+# -------------------------------------------------------------------
+
+echo ""
+echo "  $PASS passed, $FAIL failed, $TOTAL total"
+
+rm -rf "$WORK"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+echo ""
+echo "  all tests passed!"


### PR DESCRIPTION
## Summary

- Add `remember`, `recall`, `forget` as MCP tools — the natural verbs agents use for episodic memory
- `remember` auto-populates `agent_id` from MCP client info, returns concise confirmation
- `recall` does semantic search scoped to current agent, formats results for agent consumption, truncates to 32KB max payload
- `forget` deletes episodes by ID
- Custom handler dispatch in MCP server (alongside existing route-based dispatch)

## Key decisions

- `recall` defaults to current agent's memories (not global search) — Gemini review finding
- Payload truncation uses Buffer-based byte slicing to avoid splitting UTF-8 surrogate pairs
- Safe array fallback if search backend returns unexpected shape

## Test plan

- [x] 14 spike tests covering remember/recall/forget + error cases + agent ID auto-population
- [x] 349 tc tests passing (no regressions)
- [x] Gemini antagonistic review: UTF-8 truncation fix, agent scoping, safe fallbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)