### PR TITLE
Multi-agent lens isolation: per-agent knowledge spaces (#40)

### DIFF
--- a/src/handlers/mind/agent-lens/init.ts
+++ b/src/handlers/mind/agent-lens/init.ts
@@ -1,0 +1,115 @@
+//
+// agent-lens/init.ts - auto-create and activate per-agent lens
+//
+// Called during MCP initialize to give each agent its own isolated
+// knowledge space. Idempotent: re-init returns existing lens.
+//
+// Naming convention: agent-{agent_id}
+//
+
+import type { Params, Result, Emit } from "../../../lib/types.ts"
+import { success, error } from "../../../lib/result.ts"
+import { is_valid_lens_name, lens_exists, set_active_lens, get_active_lens, has_state } from "../../../lib/state.ts"
+import { sys } from "../../../index.ts"
+import { resolve } from "node:path"
+import { existsSync, mkdirSync, rmSync } from "node:fs"
+
+interface AgentLensInitParams {
+  agent_id?: string
+}
+
+interface AgentLensInitResult {
+  lens_name: string
+  created:   boolean
+}
+
+export async function handler(params: Params, emit?: Emit): Promise<Result<AgentLensInitResult>> {
+  const p = (params ?? {}) as AgentLensInitParams
+
+  // Guard: agent_id required
+  if (!p.agent_id || typeof p.agent_id !== "string" || p.agent_id.trim() === "") {
+    return error({
+      agent_id: [{
+        code:    "required",
+        message: "agent_id is required"
+      }]
+    })
+  }
+
+  const agent_id = p.agent_id.trim()
+  const lens_name = `agent-${agent_id}`
+
+  // Guard: resulting lens name must be valid
+  if (!is_valid_lens_name(lens_name)) {
+    return error({
+      agent_id: [{
+        code:    "invalid",
+        message: `agent_id produces invalid lens name: ${lens_name}`
+      }]
+    })
+  }
+
+  // Guard: state.db must exist (brane init must have been run)
+  const brane_path = resolve(process.cwd(), ".brane")
+  if (!existsSync(brane_path) || !has_state()) {
+    return error({
+      brane: [{
+        code:    "not_initialized",
+        message: "brane not initialized (run brane init)"
+      }]
+    })
+  }
+
+  // Check if lens already exists
+  if (lens_exists(lens_name)) {
+    // Just activate and return
+    set_active_lens(lens_name)
+    return success({
+      lens_name,
+      created: false
+    })
+  }
+
+  // Save previous lens for rollback on failure
+  const prev_lens = get_active_lens()
+
+  // Create lens directory
+  const lens_dir = resolve(brane_path, "lens", lens_name)
+  try {
+    mkdirSync(lens_dir, { recursive: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return error({
+      lens: [{
+        code:    "write_error",
+        message: `failed to create agent lens directory: ${message}`
+      }]
+    })
+  }
+
+  // Activate the new lens BEFORE init so body/mind init targets it
+  set_active_lens(lens_name)
+
+  // Initialize body.db in lens directory
+  const body_result = await sys.call("/body/init", { target_dir: lens_dir })
+  if (body_result.status === "error") {
+    // Rollback: revert lens, remove directory
+    set_active_lens(prev_lens)
+    try { rmSync(lens_dir, { recursive: true, force: true }) } catch {}
+    return body_result as any
+  }
+
+  // Initialize mind.db in lens directory
+  const mind_result = await sys.call("/mind/init", { target_dir: lens_dir })
+  if (mind_result.status === "error") {
+    // Rollback: revert lens, remove directory
+    set_active_lens(prev_lens)
+    try { rmSync(lens_dir, { recursive: true, force: true }) } catch {}
+    return mind_result as any
+  }
+
+  return success({
+    lens_name,
+    created: true
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import { handler as mind_episodes_get_handler } from "./handlers/mind/episodes/g
 import { handler as mind_episodes_list_handler } from "./handlers/mind/episodes/list.ts"
 import { handler as mind_episodes_search_handler } from "./handlers/mind/episodes/search.ts"
 import { handler as mind_episodes_delete_handler } from "./handlers/mind/episodes/delete.ts"
+import { handler as mind_agent_lens_init_handler } from "./handlers/mind/agent-lens/init.ts"
 
 sys.register("/ping", ping_handler)
 sys.register("/body/init", body_init_handler)
@@ -136,6 +137,7 @@ sys.register("/mind/episodes/get", mind_episodes_get_handler)
 sys.register("/mind/episodes/list", mind_episodes_list_handler)
 sys.register("/mind/episodes/search", mind_episodes_search_handler)
 sys.register("/mind/episodes/delete", mind_episodes_delete_handler)
+sys.register("/mind/agent-lens/init", mind_agent_lens_init_handler)
 
 // export
 export { sys }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -372,11 +372,16 @@ let initialized = false
 // Handle initialize
 //
 
-function handle_initialize(params: Record<string, unknown>): unknown {
+async function handle_initialize(params: Record<string, unknown>): Promise<unknown> {
   // Extract agent_id from client info
   const client_info = params.clientInfo as { name?: string } | undefined
   if (client_info?.name) {
     mcp_agent_id = client_info.name
+  }
+
+  // Auto-create per-agent lens for isolation (#40)
+  if (mcp_agent_id !== "unknown") {
+    await sys.call("/mind/agent-lens/init", { agent_id: mcp_agent_id })
   }
 
   return {
@@ -899,7 +904,7 @@ async function handle_jsonrpc_message(raw: string): Promise<string | null> {
 
     switch (req.method) {
       case "initialize":
-        result = handle_initialize(req.params ?? {})
+        result = await handle_initialize(req.params ?? {})
         break
       case "ping":
         result = {}

--- a/try/multi-agent-spike.sh
+++ b/try/multi-agent-spike.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: multi-agent lens isolation (#40)
+#
+# Tests:
+#   1. MCP initialize auto-creates agent lens
+#   2. Agent writes scope to its own lens
+#   3. Different agents get different lenses
+#   4. Agent can read from shared lens (read-only)
+#   5. Agent naming convention enforced
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+brane() { (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" "$@"); }
+
+echo "=== Multi-Agent Lens Isolation Spike ==="
+echo ""
+
+# ─────────────────────────────────────────────────────────────────
+# Setup: init body + mind + state on default lens
+# ─────────────────────────────────────────────────────────────────
+echo "--- Setup ---"
+brane /body/init > /dev/null 2>&1
+brane /state/init > /dev/null 2>&1
+brane /mind/init > /dev/null 2>&1
+pass "default lens initialized"
+
+# ─────────────────────────────────────────────────────────────────
+# Test 1: Agent lens auto-creation via MCP initialize
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Agent lens auto-creation ---"
+
+# Simulate MCP initialize with agent name "claude-code"
+INIT_RESULT=$(echo '{"agent_id": "claude-code"}' | brane /mind/agent-lens/init 2>/dev/null)
+INIT_STATUS=$(echo "$INIT_RESULT" | jq -r '.status')
+
+if [ "$INIT_STATUS" = "success" ]; then
+  pass "agent lens init succeeds"
+else
+  fail "agent lens init" "$INIT_RESULT"
+fi
+
+# Verify lens was created with correct name
+LENS_NAME=$(echo "$INIT_RESULT" | jq -r '.result.lens_name')
+if [ "$LENS_NAME" = "agent-claude-code" ]; then
+  pass "lens name follows convention: $LENS_NAME"
+else
+  fail "lens naming" "expected agent-claude-code, got $LENS_NAME"
+fi
+
+# Verify lens is now active
+ACTIVE=$(brane /lens/list 2>/dev/null | jq -r '.result.lenses[] | select(.active == true) | .name')
+if [ "$ACTIVE" = "agent-claude-code" ]; then
+  pass "agent lens is active"
+else
+  fail "active lens" "expected agent-claude-code, got $ACTIVE"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 2: Agent writes scope to its own lens
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Agent write isolation ---"
+
+# Create concept in agent lens
+CONCEPT=$(echo '{"name": "AuthService", "type": "Entity"}' | brane /mind/concepts/create 2>/dev/null)
+CONCEPT_STATUS=$(echo "$CONCEPT" | jq -r '.status')
+
+if [ "$CONCEPT_STATUS" = "success" ]; then
+  pass "created concept in agent lens"
+else
+  fail "concept create" "$CONCEPT"
+fi
+
+# Verify concept exists in agent lens
+CONCEPTS=$(echo '{}' | brane /mind/concepts/list 2>/dev/null)
+CONCEPT_COUNT=$(echo "$CONCEPTS" | jq '.result.concepts | length')
+if [ "$CONCEPT_COUNT" -eq 1 ]; then
+  pass "concept visible in agent lens"
+else
+  fail "concept count" "expected 1, got $CONCEPT_COUNT"
+fi
+
+# Switch to default lens and verify concept is NOT visible
+brane /lens/use '{"name": "default"}' > /dev/null 2>&1
+DEFAULT_CONCEPTS=$(echo '{}' | brane /mind/concepts/list 2>/dev/null)
+DEFAULT_COUNT=$(echo "$DEFAULT_CONCEPTS" | jq '.result.concepts | length')
+if [ "$DEFAULT_COUNT" -eq 0 ]; then
+  pass "concept NOT visible in default lens (isolated)"
+else
+  fail "isolation" "default lens has $DEFAULT_COUNT concepts, expected 0"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 3: Different agents get different lenses
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Multi-agent isolation ---"
+
+# Init second agent
+INIT2=$(echo '{"agent_id": "gemini-pro"}' | brane /mind/agent-lens/init 2>/dev/null)
+INIT2_STATUS=$(echo "$INIT2" | jq -r '.status')
+LENS2_NAME=$(echo "$INIT2" | jq -r '.result.lens_name')
+
+if [ "$INIT2_STATUS" = "success" ] && [ "$LENS2_NAME" = "agent-gemini-pro" ]; then
+  pass "second agent lens created: $LENS2_NAME"
+else
+  fail "second agent" "$INIT2"
+fi
+
+# Create different concept in second agent's lens
+echo '{"name": "DatabasePool", "type": "Entity"}' | brane /mind/concepts/create > /dev/null 2>&1
+
+# Verify second agent has its own concept
+AGENT2_CONCEPTS=$(echo '{}' | brane /mind/concepts/list 2>/dev/null)
+AGENT2_COUNT=$(echo "$AGENT2_CONCEPTS" | jq '.result.concepts | length')
+AGENT2_NAME=$(echo "$AGENT2_CONCEPTS" | jq -r '.result.concepts[0].name')
+if [ "$AGENT2_COUNT" -eq 1 ] && [ "$AGENT2_NAME" = "DatabasePool" ]; then
+  pass "second agent has only its own concept ($AGENT2_NAME)"
+else
+  fail "agent2 isolation" "count=$AGENT2_COUNT, name=$AGENT2_NAME"
+fi
+
+# List all lenses — should have default, agent-claude-code, agent-gemini-pro
+LENSES=$(brane /lens/list 2>/dev/null | jq -c '[.result.lenses[].name] | sort')
+EXPECTED='["agent-claude-code","agent-gemini-pro","default"]'
+if [ "$LENSES" = "$EXPECTED" ]; then
+  pass "all three lenses exist: $LENSES"
+else
+  fail "lens list" "expected $EXPECTED, got $LENSES"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 4: Idempotent — re-init same agent doesn't create duplicate
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Idempotent ---"
+
+REINIT=$(echo '{"agent_id": "claude-code"}' | brane /mind/agent-lens/init 2>/dev/null)
+REINIT_STATUS=$(echo "$REINIT" | jq -r '.status')
+REINIT_CREATED=$(echo "$REINIT" | jq -r '.result.created')
+
+if [ "$REINIT_STATUS" = "success" ] && [ "$REINIT_CREATED" = "false" ]; then
+  pass "re-init is idempotent (created=false)"
+else
+  fail "idempotent" "$REINIT"
+fi
+
+# Verify first agent's concept still exists
+AGENT1_CONCEPTS=$(echo '{}' | brane /mind/concepts/list 2>/dev/null)
+AGENT1_COUNT=$(echo "$AGENT1_CONCEPTS" | jq '.result.concepts | length')
+if [ "$AGENT1_COUNT" -eq 1 ]; then
+  pass "agent data preserved after re-init"
+else
+  fail "data preservation" "expected 1 concept, got $AGENT1_COUNT"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 5: Validation
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Validation ---"
+
+# Empty agent_id
+EMPTY=$(echo '{}' | brane /mind/agent-lens/init 2>/dev/null || true)
+EMPTY_STATUS=$(echo "$EMPTY" | jq -r '.status')
+if [ "$EMPTY_STATUS" = "error" ]; then
+  pass "empty agent_id rejected"
+else
+  fail "validation" "empty agent_id should fail"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Results
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+echo ""
+echo "  $PASS passed, $FAIL failed, $TOTAL total"
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo "  all tests passed!"
+else
+  echo "  FAILURES DETECTED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `/mind/agent-lens/init` handler: auto-creates isolated lens per agent
- MCP `initialize` auto-creates `agent-{clientInfo.name}` lens on connect
- Each agent writes to its own body.db + mind.db (full isolation)
- Idempotent: re-init activates existing lens, preserves data
- Rollback on partial init failure (reverts active lens, removes directory)

## Test plan
- [x] Spike: 13/13 tests pass (`try/multi-agent-spike.sh`)
- [x] Full suite: 349/0 tc tests pass
- [x] Gemini review incorporated (rollback on failure, lens state revert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)