### PR TITLE
MCP prompts: reasoning templates for agents (#42)

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -419,6 +419,168 @@ const RESOURCE_TEMPLATES: McpResourceTemplate[] = [
 ]
 
 //
+// MCP Prompt definitions (#42)
+//
+
+interface McpPromptDef {
+  name:        string
+  description: string
+  arguments?:  { name: string; description: string; required: boolean }[]
+}
+
+const PROMPTS: McpPromptDef[] = [
+  {
+    name:        "memory-protocol",
+    description: "System prompt for how to use brane as memory — when to remember, recall, learn, and reflect",
+  },
+  {
+    name:        "pre-task-recall",
+    description: "Recall relevant memories before starting a task",
+    arguments:   [{ name: "task_description", description: "What you are about to do", required: true }],
+  },
+  {
+    name:        "post-task-remember",
+    description: "Remember what was learned after completing a task",
+    arguments:   [
+      { name: "task_description", description: "What you just did", required: true },
+      { name: "outcome", description: "What happened — success, failure, surprising findings", required: true },
+    ],
+  },
+  {
+    name:        "codebase-analysis",
+    description: "Systematic approach to learning a new codebase via brane",
+    arguments:   [{ name: "path", description: "Path to the codebase or directory to analyze", required: true }],
+  },
+  {
+    name:        "knowledge-audit",
+    description: "Review and clean up accumulated knowledge — find gaps, stale entries, consolidation opportunities",
+  },
+]
+
+type PromptRenderer = (args: Record<string, string>) => { role: string; content: { type: string; text: string } }[]
+
+const PROMPT_CONTENT: Record<string, PromptRenderer> = {
+  "memory-protocol": () => [{
+    role: "user",
+    content: {
+      type: "text",
+      text: `You have access to brane, a deterministic subjective memory system.
+
+USE \`remember\` when:
+- You learn something surprising or non-obvious
+- A task succeeds or fails in an unexpected way
+- You discover a pattern across multiple files/interactions
+- The user shares context you'll need in future conversations
+
+USE \`recall\` when:
+- Starting a new task (check for relevant past experience)
+- Encountering an error (have you seen this before?)
+- Making a design decision (what worked last time?)
+- The user references something from a previous session
+
+USE \`learn\` when:
+- The user points you at new files or codebases
+- You need deep structural understanding of code
+- You want to build a knowledge graph of concepts and relationships
+
+USE \`reflect\` when:
+- You want to check how much you know about a topic
+- Before making recommendations based on accumulated knowledge
+- You need a summary of what you've learned so far
+
+GENERAL PRINCIPLES:
+- Remember outcomes, not just actions
+- Be specific: "auth middleware timeout in CI" > "something broke"
+- Tag observations to enable future filtering
+- Reflect periodically to consolidate scattered episodes into knowledge`
+    }
+  }],
+
+  "pre-task-recall": (args) => [{
+    role: "user",
+    content: {
+      type: "text",
+      text: `Before starting this task, recall any relevant memories from brane.
+
+TASK: ${args.task_description ?? "(no task specified)"}
+
+Steps:
+1. Use \`recall\` with keywords from the task description
+2. Use \`ask\` to search the knowledge graph for related concepts
+3. Review any relevant episodes (past experiences with similar tasks)
+4. Note any patterns, warnings, or successful approaches from past work
+5. Proceed with the task, informed by your recalled context`
+    }
+  }],
+
+  "post-task-remember": (args) => [{
+    role: "user",
+    content: {
+      type: "text",
+      text: `You just completed a task. Remember what you learned for next time.
+
+TASK: ${args.task_description ?? "(no task specified)"}
+OUTCOME: ${args.outcome ?? "(no outcome specified)"}
+
+Remember:
+1. What was the task and what happened?
+2. Were there any surprises or unexpected challenges?
+3. What approach worked (or didn't)?
+4. What would you do differently next time?
+5. Are there any concepts or relationships worth adding to the knowledge graph?
+
+Use \`remember\` to save the key takeaways as episodic memories.
+Use \`learn\` if you discovered structural relationships worth capturing.`
+    }
+  }],
+
+  "codebase-analysis": (args) => [{
+    role: "user",
+    content: {
+      type: "text",
+      text: `Systematically analyze and learn a codebase using brane.
+
+TARGET: ${args.path ?? "(no path specified)"}
+
+Approach:
+1. Start with the entry point (main, index, app)
+2. Identify key modules, services, and their responsibilities
+3. Map dependencies between components
+4. Note any patterns, conventions, or architectural decisions
+5. Identify potential issues (circular deps, tight coupling, etc.)
+
+For each component you discover:
+- Use \`learn\` to add it as a concept with the right type (Entity, Module, Service, etc.)
+- Use \`relate\` to capture relationships (DEPENDS_ON, CONTAINS, IMPLEMENTS)
+- Use \`remember\` for observations about code quality, conventions, or gotchas
+
+End with \`reflect\` to summarize what you've learned.`
+    }
+  }],
+
+  "knowledge-audit": () => [{
+    role: "user",
+    content: {
+      type: "text",
+      text: `Audit your accumulated brane knowledge. Find gaps, stale entries, and consolidation opportunities.
+
+Steps:
+1. Use \`reflect\` to get a high-level summary of what's in the knowledge graph
+2. Review the concept types — are they consistent? Any duplicates?
+3. Check edge relationships — do they accurately represent the codebase?
+4. Look at recent episodes — any that should be consolidated into concepts?
+5. Identify knowledge gaps — what important parts of the system are missing?
+
+Actions:
+- Use \`decay\` (dry run) to see which memories are losing relevance
+- Use \`consolidate\` (dry run) to see which episodes could merge into concepts
+- Clean up duplicates or incorrect relationships
+- Add missing concepts for important system components`
+    }
+  }],
+}
+
+//
 // Max payload size for recall results (bytes). Prevents overflowing agent context windows.
 //
 const MAX_RECALL_PAYLOAD = 32 * 1024  // 32KB
@@ -452,7 +614,7 @@ async function handle_initialize(params: Record<string, unknown>): Promise<unkno
 
   return {
     protocolVersion: MCP_VERSION,
-    capabilities: { tools: {}, resources: {} },
+    capabilities: { tools: {}, resources: {}, prompts: {} },
     serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
   }
 }
@@ -609,6 +771,35 @@ async function handle_resources_read(params: Record<string, unknown>): Promise<u
   }
 
   throw new McpError(-32602, `Unknown resource URI: ${uri}`)
+}
+
+//
+// Handle prompts/list
+//
+
+function handle_prompts_list(): unknown {
+  return { prompts: PROMPTS }
+}
+
+//
+// Handle prompts/get
+//
+
+function handle_prompts_get(params: Record<string, unknown>): unknown {
+  const name = String(params.name ?? "")
+  const renderer = PROMPT_CONTENT[name]
+
+  if (!renderer) {
+    throw new McpError(-32602, `Unknown prompt: ${name}`)
+  }
+
+  const args = (params.arguments ?? {}) as Record<string, string>
+  const messages = renderer(args)
+
+  return {
+    description: PROMPTS.find(p => p.name === name)?.description ?? "",
+    messages,
+  }
 }
 
 class McpError extends Error {
@@ -1143,6 +1334,12 @@ async function handle_jsonrpc_message(raw: string): Promise<string | null> {
         break
       case "resources/read":
         result = await handle_resources_read(req.params ?? {})
+        break
+      case "prompts/list":
+        result = handle_prompts_list()
+        break
+      case "prompts/get":
+        result = handle_prompts_get(req.params ?? {})
         break
       default: {
         const resp: JsonRpcResponse = {

--- a/try/mcp-prompts-spike.sh
+++ b/try/mcp-prompts-spike.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: MCP prompts (#42)
+#
+# Tests:
+#   1. prompts/list returns all prompt definitions
+#   2. prompts/get returns prompt content
+#   3. Argument interpolation works
+#   4. Unknown prompt returns error
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+echo "=== MCP Prompts Spike ==="
+echo ""
+
+# ─────────────────────────────────────────────────────────────────
+# Setup: build binary for MCP testing
+# ─────────────────────────────────────────────────────────────────
+echo "--- Setup ---"
+
+# Init workspace
+(cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" /body/init > /dev/null 2>&1)
+(cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" /state/init > /dev/null 2>&1)
+
+# Build binary for MCP stdin testing
+bun build "$BRANE_ROOT/src/cli.ts" --compile --outfile "$BRANE_ROOT/brane" > /dev/null 2>&1
+BRANE_BIN="$BRANE_ROOT/brane"
+pass "setup complete"
+
+# ─────────────────────────────────────────────────────────────────
+# Test 1: prompts/list via compiled binary
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- prompts/list ---"
+
+INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+NOTIF='{"jsonrpc":"2.0","method":"notifications/initialized"}'
+PLIST='{"jsonrpc":"2.0","id":2,"method":"prompts/list"}'
+
+RESPONSES=$(printf '%s\n%s\n%s\n' "$INIT" "$NOTIF" "$PLIST" \
+  | (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 "$BRANE_BIN" mcp 2>/dev/null))
+
+LIST_RESP=$(echo "$RESPONSES" | grep '"jsonrpc"' | sed -n '2p')
+PROMPT_COUNT=$(echo "$LIST_RESP" | jq '.result.prompts | length' 2>/dev/null || echo "0")
+
+if [ "$PROMPT_COUNT" -ge 5 ]; then
+  pass "prompts/list returns $PROMPT_COUNT prompts"
+else
+  fail "prompts/list" "expected >= 5, got $PROMPT_COUNT. Response: $LIST_RESP"
+fi
+
+# Check specific prompts exist
+for NAME in memory-protocol pre-task-recall post-task-remember codebase-analysis knowledge-audit; do
+  HAS=$(echo "$LIST_RESP" | jq "[.result.prompts[].name] | map(select(. == \"$NAME\")) | length")
+  if [ "$HAS" -eq 1 ]; then
+    pass "prompt '$NAME' listed"
+  else
+    fail "prompt $NAME" "not found"
+  fi
+done
+
+# ─────────────────────────────────────────────────────────────────
+# Test 2: prompts/get - memory-protocol (no args)
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- prompts/get (memory-protocol) ---"
+
+PGET='{"jsonrpc":"2.0","id":3,"method":"prompts/get","params":{"name":"memory-protocol"}}'
+GET_RESP=$(printf '%s\n%s\n%s\n' "$INIT" "$NOTIF" "$PGET" \
+  | (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 "$BRANE_BIN" mcp 2>/dev/null) \
+  | grep '"jsonrpc"' | sed -n '2p')
+
+MSG_COUNT=$(echo "$GET_RESP" | jq '.result.messages | length' 2>/dev/null || echo "0")
+if [ "$MSG_COUNT" -ge 1 ]; then
+  pass "memory-protocol has $MSG_COUNT message(s)"
+else
+  fail "memory-protocol" "no messages: $GET_RESP"
+fi
+
+HAS_REMEMBER=$(echo "$GET_RESP" | jq -r '.result.messages[0].content.text' | grep -c "remember" || true)
+if [ "$HAS_REMEMBER" -ge 1 ]; then
+  pass "memory-protocol mentions 'remember'"
+else
+  fail "memory-protocol content" "doesn't mention remember"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 3: prompts/get with arguments
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- prompts/get (pre-task-recall with args) ---"
+
+PGET_ARGS='{"jsonrpc":"2.0","id":4,"method":"prompts/get","params":{"name":"pre-task-recall","arguments":{"task_description":"fix the auth middleware timeout bug"}}}'
+ARGS_RESP=$(printf '%s\n%s\n%s\n' "$INIT" "$NOTIF" "$PGET_ARGS" \
+  | (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 "$BRANE_BIN" mcp 2>/dev/null) \
+  | grep '"jsonrpc"' | sed -n '2p')
+
+ARGS_TEXT=$(echo "$ARGS_RESP" | jq -r '.result.messages[0].content.text' 2>/dev/null || echo "")
+HAS_TASK=$(echo "$ARGS_TEXT" | grep -c "auth middleware timeout" || true)
+if [ "$HAS_TASK" -ge 1 ]; then
+  pass "pre-task-recall interpolates task_description"
+else
+  fail "interpolation" "task not found in text: $ARGS_TEXT"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 4: prompts/get for post-task-remember
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- prompts/get (post-task-remember) ---"
+
+PGET_POST='{"jsonrpc":"2.0","id":5,"method":"prompts/get","params":{"name":"post-task-remember","arguments":{"task_description":"deploy v2","outcome":"rolled back due to DB migration"}}}'
+POST_RESP=$(printf '%s\n%s\n%s\n' "$INIT" "$NOTIF" "$PGET_POST" \
+  | (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 "$BRANE_BIN" mcp 2>/dev/null) \
+  | grep '"jsonrpc"' | sed -n '2p')
+
+POST_TEXT=$(echo "$POST_RESP" | jq -r '.result.messages[0].content.text' 2>/dev/null || echo "")
+HAS_OUTCOME=$(echo "$POST_TEXT" | grep -c "rolled back" || true)
+if [ "$HAS_OUTCOME" -ge 1 ]; then
+  pass "post-task-remember interpolates outcome"
+else
+  fail "outcome interpolation" "$POST_TEXT"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 5: prompts/get for unknown prompt
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Error handling ---"
+
+PGET_BAD='{"jsonrpc":"2.0","id":6,"method":"prompts/get","params":{"name":"nonexistent"}}'
+BAD_RESP=$(printf '%s\n%s\n%s\n' "$INIT" "$NOTIF" "$PGET_BAD" \
+  | (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 "$BRANE_BIN" mcp 2>/dev/null) \
+  | grep '"jsonrpc"' | sed -n '2p')
+
+HAS_ERR=$(echo "$BAD_RESP" | jq 'has("error")' 2>/dev/null || echo "false")
+if [ "$HAS_ERR" = "true" ]; then
+  pass "unknown prompt returns error"
+else
+  fail "error handling" "$BAD_RESP"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 6: Capabilities advertise prompts
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Capabilities ---"
+
+if grep -q 'prompts: {}' "$BRANE_ROOT/src/mcp.ts"; then
+  pass "prompts capability advertised"
+else
+  fail "capabilities" "prompts not in capabilities"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Results
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+echo ""
+echo "  $PASS passed, $FAIL failed, $TOTAL total"
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo "  all tests passed!"
+else
+  echo "  FAILURES DETECTED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `prompts/list` and `prompts/get` MCP methods
- 5 prompt templates: memory-protocol, pre-task-recall, post-task-remember, codebase-analysis, knowledge-audit
- Argument interpolation for task-specific context
- Prompts capability advertised in MCP initialize

## Test plan
- [x] Spike: 13/13 tests pass (`try/mcp-prompts-spike.sh`)
- [x] Full suite: 349/0 tc tests pass
- [x] MCP integration via compiled binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)