### PR TITLE
Binary distribution: standalone installable (#43)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,33 @@ env:
   NAPI_VERSION: "6"
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Download CozoDB native binary
+        run: |
+          mkdir -p node_modules/cozo-node/cozo-lib-nodejs/native
+          curl -fsSL "https://github.com/cozodb/cozo-lib-nodejs/releases/download/${{ env.COZO_VERSION }}/${{ env.NAPI_VERSION }}-linux-x64.tar.gz" \
+            | tar -xzf - -C node_modules/cozo-node/cozo-lib-nodejs/native
+
+      - name: Run tests
+        run: BRANE_EMBED_MOCK=1 bun run src/tc.ts
+
   build:
     name: Build ${{ matrix.platform }}
+    needs: test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,9 +59,6 @@ jobs:
           - platform: darwin-arm64
             bun_target: bun-darwin-arm64
             artifact: brane-darwin-arm64
-          - platform: win32-x64
-            bun_target: bun-windows-x64
-            artifact: brane-windows-x64.exe
 
     steps:
       - name: Checkout
@@ -52,24 +74,27 @@ jobs:
 
       - name: Download CozoDB native binary
         run: |
-          # Archive contains 6/cozo_node_prebuilt.node, so extract to native/
-          # Using ahoward/cozo fork, nodejs package is in cozo-lib-nodejs/
           mkdir -p node_modules/cozo-node/cozo-lib-nodejs/native
           curl -fsSL "https://github.com/cozodb/cozo-lib-nodejs/releases/download/${{ env.COZO_VERSION }}/${{ env.NAPI_VERSION }}-${{ matrix.platform }}.tar.gz" \
             | tar -xzf - -C node_modules/cozo-node/cozo-lib-nodejs/native
 
       - name: Get version
         id: version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           else
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            # Sanitize: strip anything that isn't alphanumeric, dots, or hyphens
+            CLEAN=$(echo "$INPUT_VERSION" | tr -cd 'a-zA-Z0-9.-')
+            echo "version=${CLEAN}" >> $GITHUB_OUTPUT
           fi
 
       - name: Build binary
         run: |
           bun build --compile --target=${{ matrix.bun_target }} --minify \
+            --define "BRANE_VERSION='\"${{ steps.version.outputs.version }}\"'" \
             src/cli.ts --outfile dist/${{ matrix.artifact }}
 
       - name: Upload artifact
@@ -93,8 +118,15 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum brane-* > checksums.txt
+          cat checksums.txt
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: dist/*
+          files: |
+            dist/*
           generate_release_notes: true

--- a/scripts/homebrew/brane.rb
+++ b/scripts/homebrew/brane.rb
@@ -1,0 +1,49 @@
+# typed: false
+# frozen_string_literal: true
+
+# Homebrew formula for brane
+#
+# Install:
+#   brew tap ahoward/tap
+#   brew install brane
+#
+# This formula downloads pre-built binaries from GitHub Releases.
+# To create a tap, copy this file to homebrew-tap/Formula/brane.rb
+# and update the version/sha256 values on each release.
+#
+
+class Brane < Formula
+  desc "Semantic Nervous System - Knowledge Graph for AI Agents (MCP)"
+  homepage "https://github.com/ahoward/brane"
+  version "VERSION"  # replaced by release script
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/ahoward/brane/releases/download/v#{version}/brane-darwin-arm64"
+      sha256 "SHA256_DARWIN_ARM64"  # replaced by release script
+    else
+      url "https://github.com/ahoward/brane/releases/download/v#{version}/brane-darwin-x64"
+      sha256 "SHA256_DARWIN_X64"  # replaced by release script
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/ahoward/brane/releases/download/v#{version}/brane-linux-arm64"
+      sha256 "SHA256_LINUX_ARM64"  # replaced by release script
+    else
+      url "https://github.com/ahoward/brane/releases/download/v#{version}/brane-linux-x64"
+      sha256 "SHA256_LINUX_X64"  # replaced by release script
+    end
+  end
+
+  def install
+    binary = Dir.glob("brane-*").first || "brane"
+    bin.install binary => "brane"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/brane --version")
+  end
+end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Brane installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/ahoward/brane/main/scripts/install.sh | bash
+#
+# Options (via env vars):
+#   BRANE_VERSION=0.1.0   Install a specific version (default: latest)
+#   BRANE_INSTALL_DIR=/usr/local/bin  Install directory (default: ~/.local/bin)
+#
+set -euo pipefail
+
+REPO="ahoward/brane"
+INSTALL_DIR="${BRANE_INSTALL_DIR:-$HOME/.local/bin}"
+
+# Detect platform
+detect_platform() {
+  local os arch
+
+  case "$(uname -s)" in
+    Linux*)  os="linux" ;;
+    Darwin*) os="darwin" ;;
+    *)
+      echo "error: unsupported OS: $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *)
+      echo "error: unsupported architecture: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "${os}-${arch}"
+}
+
+# Get latest version tag from GitHub (avoids API rate limits)
+get_latest_version() {
+  # Follow redirect from /releases/latest to get the tag
+  local url
+  url=$(curl -fsSL -o /dev/null -w "%{url_effective}" "https://github.com/${REPO}/releases/latest" 2>/dev/null || true)
+
+  if [ -n "$url" ]; then
+    echo "$url" | grep -o 'v[0-9][0-9.]*' | sed 's/^v//'
+  fi
+}
+
+main() {
+  local platform version artifact url tmpfile
+
+  platform=$(detect_platform)
+  echo "Platform: ${platform}"
+
+  # Determine version
+  if [ -n "${BRANE_VERSION:-}" ]; then
+    version="$BRANE_VERSION"
+    echo "Version: ${version} (specified)"
+  else
+    version=$(get_latest_version)
+    if [ -z "$version" ]; then
+      echo "error: could not determine latest version. Set BRANE_VERSION manually." >&2
+      exit 1
+    fi
+    echo "Version: ${version} (latest)"
+  fi
+
+  artifact="brane-${platform}"
+  url="https://github.com/${REPO}/releases/download/v${version}/${artifact}"
+
+  echo "Downloading: ${url}"
+
+  # Create install directory
+  mkdir -p "$INSTALL_DIR"
+
+  # Atomic download: write to temp file, then move
+  tmpfile=$(mktemp "${INSTALL_DIR}/brane.XXXXXX")
+  trap "rm -f '$tmpfile'" EXIT
+
+  if ! curl -fsSL "$url" -o "$tmpfile"; then
+    echo "error: download failed. Check that version v${version} exists and has a ${platform} binary." >&2
+    exit 1
+  fi
+
+  chmod +x "$tmpfile"
+  mv "$tmpfile" "${INSTALL_DIR}/brane"
+  trap - EXIT  # clear trap on success
+
+  echo ""
+  echo "Installed brane to ${INSTALL_DIR}/brane"
+
+  # Check if install dir is on PATH
+  if ! echo "$PATH" | tr ':' '\n' | grep -q "^${INSTALL_DIR}$"; then
+    echo ""
+    echo "Note: ${INSTALL_DIR} is not on your PATH."
+    echo "Add it with:"
+    echo ""
+    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    echo ""
+    echo "Or add that line to your ~/.bashrc or ~/.zshrc"
+  fi
+
+  echo ""
+  echo "Verify with: brane --version"
+}
+
+main

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { start_repl } from "./repl.ts"
 import { run_mcp_server } from "./mcp.ts"
 import { runMain } from "citty"
 import { main, subCommandAliases } from "./cli/main.ts"
+import { get_version } from "./version.ts"
 
 //
 // Read stdin (for API mode)
@@ -143,6 +144,12 @@ async function main_entry(): Promise<void> {
   // No args → REPL
   if (args.length === 0) {
     await start_repl()
+    return
+  }
+
+  // Version flag
+  if (args[0] === "--version" || args[0] === "-V") {
+    console.log(get_version())
     return
   }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -3,6 +3,7 @@
 //
 
 import { defineCommand } from "citty"
+import { get_version } from "../version.ts"
 
 // Import all commands
 import { init } from "./commands/init.ts"
@@ -25,7 +26,7 @@ import { prune } from "./commands/prune.ts"
 export const main = defineCommand({
   meta: {
     name: "brane",
-    version: "0.1.0",
+    version: get_version(),
     description: "Semantic Nervous System - Knowledge Graph CLI",
   },
   subCommands: {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,18 @@
+//
+// version.ts - brane version
+//
+// At build time, BRANE_VERSION env is baked in via --define.
+// At dev time, falls back to package.json version + "-dev".
+//
+
+declare const BRANE_VERSION: string | undefined
+
+export function get_version(): string {
+  // Build-time injected version (from git tag)
+  if (typeof BRANE_VERSION !== "undefined" && BRANE_VERSION) {
+    return BRANE_VERSION
+  }
+
+  // Dev fallback
+  return "0.1.0-dev"
+}

--- a/try/binary-distribution-spike.sh
+++ b/try/binary-distribution-spike.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: Binary Distribution (#43)
+#
+# Tests:
+#   1. version module exists and exports
+#   2. brane --version outputs version string
+#   3. brane -V outputs version string
+#   4. CLI main.ts uses dynamic version
+#   5. Release workflow exists with test step
+#   6. Release workflow builds all 4 targets
+#   7. Install script exists and is valid bash
+#   8. Install script detects platform
+#   9. Homebrew formula template exists
+#  10. Compiled binary reports version
+#  11. Source code integration
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+echo "=== Binary Distribution Spike ==="
+echo ""
+
+# ─────────────────────────────────────────────────────────────────
+# Test 1: Version module
+# ─────────────────────────────────────────────────────────────────
+echo "--- Version module ---"
+
+if [ -f "$BRANE_ROOT/src/version.ts" ]; then
+  pass "version.ts exists"
+else
+  fail "module" "src/version.ts not found"
+fi
+
+VER_TEST=$(bun -e "
+const { get_version } = require('$BRANE_ROOT/src/version.ts');
+console.log('version:', get_version());
+console.log('has_fn:', typeof get_version === 'function');
+" 2>/dev/null)
+
+if echo "$VER_TEST" | grep -q "has_fn: true"; then
+  pass "exports get_version"
+else
+  fail "exports" "get_version not exported"
+fi
+
+if echo "$VER_TEST" | grep -q "version: "; then
+  VER=$(echo "$VER_TEST" | grep "version:" | awk '{print $2}')
+  pass "returns version: $VER"
+else
+  fail "version" "no version returned"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 2: CLI --version flag
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- CLI version flags ---"
+
+VERSION_OUTPUT=$(bun run "$BRANE_ROOT/src/cli.ts" --version 2>/dev/null || true)
+if [ -n "$VERSION_OUTPUT" ]; then
+  pass "brane --version outputs: $VERSION_OUTPUT"
+else
+  fail "--version" "no output from --version"
+fi
+
+V_OUTPUT=$(bun run "$BRANE_ROOT/src/cli.ts" -V 2>/dev/null || true)
+if [ -n "$V_OUTPUT" ]; then
+  pass "brane -V outputs: $V_OUTPUT"
+else
+  fail "-V" "no output from -V"
+fi
+
+# Should match
+if [ "$VERSION_OUTPUT" = "$V_OUTPUT" ]; then
+  pass "--version and -V output match"
+else
+  fail "match" "--version ($VERSION_OUTPUT) != -V ($V_OUTPUT)"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 3: Dynamic version in main.ts
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Dynamic version ---"
+
+if grep -q 'get_version' "$BRANE_ROOT/src/cli/main.ts"; then
+  pass "main.ts uses get_version()"
+else
+  fail "dynamic" "main.ts doesn't use get_version()"
+fi
+
+if ! grep -q "version: \"0.1.0\"" "$BRANE_ROOT/src/cli/main.ts"; then
+  pass "no hardcoded version in main.ts"
+else
+  fail "hardcoded" "main.ts still has hardcoded version"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 4: Release workflow
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Release workflow ---"
+
+if [ -f "$BRANE_ROOT/.github/workflows/release.yml" ]; then
+  pass "release.yml exists"
+else
+  fail "workflow" "release.yml not found"
+fi
+
+# Test step exists
+if grep -q "Run tests" "$BRANE_ROOT/.github/workflows/release.yml"; then
+  pass "workflow has test step"
+else
+  fail "tests" "no test step in workflow"
+fi
+
+# Tests run before build
+if grep -q "needs: test" "$BRANE_ROOT/.github/workflows/release.yml"; then
+  pass "build depends on test"
+else
+  fail "ordering" "build doesn't depend on test"
+fi
+
+# All 4 platform targets
+for target in "linux-x64" "linux-arm64" "darwin-x64" "darwin-arm64"; do
+  if grep -q "$target" "$BRANE_ROOT/.github/workflows/release.yml"; then
+    pass "workflow builds $target"
+  else
+    fail "target" "$target not in workflow"
+  fi
+done
+
+# Version injection at build time
+if grep -q "BRANE_VERSION" "$BRANE_ROOT/.github/workflows/release.yml"; then
+  pass "workflow injects BRANE_VERSION at build"
+else
+  fail "version" "BRANE_VERSION not injected in workflow"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 5: Install script
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Install script ---"
+
+if [ -f "$BRANE_ROOT/scripts/install.sh" ]; then
+  pass "install.sh exists"
+else
+  fail "install" "scripts/install.sh not found"
+fi
+
+if [ -x "$BRANE_ROOT/scripts/install.sh" ]; then
+  pass "install.sh is executable"
+else
+  fail "install" "install.sh not executable"
+fi
+
+# Validate bash syntax
+if bash -n "$BRANE_ROOT/scripts/install.sh" 2>/dev/null; then
+  pass "install.sh is valid bash"
+else
+  fail "syntax" "install.sh has bash syntax errors"
+fi
+
+# Platform detection function exists
+if grep -q "detect_platform" "$BRANE_ROOT/scripts/install.sh"; then
+  pass "install.sh has platform detection"
+else
+  fail "platform" "no detect_platform in install.sh"
+fi
+
+# Handles linux and darwin
+if grep -q "Linux" "$BRANE_ROOT/scripts/install.sh" && grep -q "Darwin" "$BRANE_ROOT/scripts/install.sh"; then
+  pass "install.sh handles Linux and Darwin"
+else
+  fail "platforms" "missing Linux/Darwin handling"
+fi
+
+# Handles x64 and arm64
+if grep -q "x86_64" "$BRANE_ROOT/scripts/install.sh" && grep -q "arm64" "$BRANE_ROOT/scripts/install.sh"; then
+  pass "install.sh handles x64 and arm64"
+else
+  fail "arch" "missing architecture handling"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 6: Homebrew formula
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Homebrew formula ---"
+
+if [ -f "$BRANE_ROOT/scripts/homebrew/brane.rb" ]; then
+  pass "homebrew formula template exists"
+else
+  fail "homebrew" "brane.rb not found"
+fi
+
+if grep -q "class Brane < Formula" "$BRANE_ROOT/scripts/homebrew/brane.rb"; then
+  pass "formula defines Brane class"
+else
+  fail "formula" "missing Brane class"
+fi
+
+if grep -q "darwin-arm64" "$BRANE_ROOT/scripts/homebrew/brane.rb" && \
+   grep -q "darwin-x64" "$BRANE_ROOT/scripts/homebrew/brane.rb" && \
+   grep -q "linux-arm64" "$BRANE_ROOT/scripts/homebrew/brane.rb" && \
+   grep -q "linux-x64" "$BRANE_ROOT/scripts/homebrew/brane.rb"; then
+  pass "formula covers all 4 platforms"
+else
+  fail "platforms" "formula missing platform targets"
+fi
+
+if grep -q "brane --version" "$BRANE_ROOT/scripts/homebrew/brane.rb"; then
+  pass "formula has version test"
+else
+  fail "test" "formula missing version test"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 7: Compiled binary version
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Compiled binary ---"
+
+# Build with version injection
+bun build "$BRANE_ROOT/src/cli.ts" --compile --outfile "$BRANE_ROOT/brane" > /dev/null 2>&1
+
+BINARY_VER=$("$BRANE_ROOT/brane" --version 2>/dev/null || true)
+if [ -n "$BINARY_VER" ]; then
+  pass "compiled binary reports version: $BINARY_VER"
+else
+  fail "binary" "compiled binary --version failed"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Test 8: MCP server version
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- MCP server version ---"
+
+if grep -q 'SERVER_VERSION' "$BRANE_ROOT/src/mcp.ts"; then
+  pass "mcp.ts has SERVER_VERSION"
+else
+  fail "mcp" "SERVER_VERSION not in mcp.ts"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Results
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+echo ""
+echo "  $PASS passed, $FAIL failed, $TOTAL total"
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo "  all tests passed!"
+else
+  echo "  FAILURES DETECTED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Dynamic `src/version.ts` module with build-time version injection via `--define`
- `brane --version` / `brane -V` flags in CLI
- Updated release workflow: test gate, 4 platform targets (linux/darwin x x64/arm64), SHA256 checksums
- curl installer script with atomic download, platform detection, PATH guidance
- Homebrew formula template for tap distribution

## Files
- `src/version.ts` — Version module (build-time `BRANE_VERSION` or dev fallback)
- `src/cli.ts` — `--version`/`-V` flag handling
- `src/cli/main.ts` — Dynamic version from `get_version()`
- `.github/workflows/release.yml` — CI with test gate, checksums, sanitized inputs
- `scripts/install.sh` — Cross-platform curl installer
- `scripts/homebrew/brane.rb` — Homebrew formula template
- `try/binary-distribution-spike.sh` — 28/28 whitebox tests

## Gemini review fixes
- Sanitized version input in workflow (strip non-alphanumeric)
- Atomic download in installer (temp file + mv)
- Redirect-based version detection (avoids GitHub API rate limits)
- SHA256 checksums generated and attached to releases

## Test plan
- [x] Spike: 28/28 tests pass
- [x] TC suite: 349/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)