### PR TITLE
CLI session ingestion command (#77)

### DIFF
--- a/src/cli/commands/ingest-sessions.ts
+++ b/src/cli/commands/ingest-sessions.ts
@@ -1,0 +1,73 @@
+//
+// ingest-sessions.ts - CLI command for session log ingestion
+//
+
+import { defineCommand } from "citty"
+import { sys } from "../../index.ts"
+import { output } from "../output.ts"
+
+export const ingestSessions = defineCommand({
+  meta: {
+    name: "ingest-sessions",
+    description: "Ingest Claude Code session logs into episodic memory",
+  },
+  args: {
+    path:    { type: "positional", description: "Session file (.jsonl) or project dir (auto-discovers if omitted)", required: false },
+    limit:   { type: "string", alias: "l", description: "Max sessions to process (default: 10)" },
+    dryRun:  { type: "boolean", alias: "n", description: "Preview without creating episodes" },
+    agent:   { type: "string", alias: "a", description: "Agent ID for created episodes (default: claude-code)" },
+    json:    { type: "boolean", alias: "j", description: "Output as JSON" },
+  },
+  async run({ args }) {
+    const params: Record<string, unknown> = {}
+
+    if (args.path) params.path = args.path
+    if (args.limit) params.limit = parseInt(String(args.limit), 10) || 10
+    if (args.dryRun) params.dry_run = true
+    if (args.agent) params.agent_id = args.agent
+
+    const result = await sys.call("/calabi/ingest-sessions", params)
+
+    if (args.json) {
+      output(result, { json: true })
+      return
+    }
+
+    if (result.status === "error") {
+      output(result, {})
+      return
+    }
+
+    const data = result.result as {
+      sessions_found: number
+      sessions_ingested: number
+      sessions_skipped: number
+      episodes_created: number
+      dry_run: boolean
+      details: { session_id: string; turns: number; exchanges: number; episodes: number; skipped: boolean; reason?: string }[]
+    }
+
+    if (!data) return
+
+    const prefix = data.dry_run ? "[dry run] " : ""
+
+    if (data.sessions_found === 0) {
+      console.log(`${prefix}no session logs found`)
+      return
+    }
+
+    console.log(`${prefix}found ${data.sessions_found} session(s)`)
+    console.log("")
+
+    for (const d of data.details ?? []) {
+      if (d.skipped) {
+        console.log(`  skip  ${d.session_id.slice(0, 8)}…  ${d.reason}`)
+      } else {
+        console.log(`  ✓     ${d.session_id.slice(0, 8)}…  ${d.turns} turns → ${d.episodes} episodes`)
+      }
+    }
+
+    console.log("")
+    console.log(`${prefix}${data.sessions_ingested} ingested, ${data.sessions_skipped} skipped, ${data.episodes_created} episodes`)
+  },
+})

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -23,6 +23,7 @@ import { lens } from "./commands/lens.ts"
 import { graph } from "./commands/graph.ts"
 import { prune } from "./commands/prune.ts"
 import { memory } from "./commands/memory.ts"
+import { ingestSessions } from "./commands/ingest-sessions.ts"
 
 export const main = defineCommand({
   meta: {
@@ -58,6 +59,7 @@ export const main = defineCommand({
 
     // Memory commands
     memory,
+    "ingest-sessions": ingestSessions,
 
     // Graph exploration
     graph,

--- a/try/cli-ingest-sessions-spike.sh
+++ b/try/cli-ingest-sessions-spike.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: CLI Session Ingestion (#57)
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+brane() { (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" "$@"); }
+
+echo "=== CLI Session Ingestion Spike ==="
+echo ""
+
+# Setup
+brane init > /dev/null 2>&1
+
+# Create fake session log
+FAKE_DIR="$WORKSPACE/sessions"
+mkdir -p "$FAKE_DIR"
+FAKE_SESSION="$FAKE_DIR/test-session.jsonl"
+cat > "$FAKE_SESSION" << 'JSONL'
+{"type":"user","uuid":"u1","timestamp":"2026-03-27T10:00:00Z","sessionId":"spike-session","message":{"role":"user","content":"How does the auth middleware work?"},"cwd":"/tmp/test"}
+{"type":"assistant","uuid":"a1","timestamp":"2026-03-27T10:00:05Z","sessionId":"spike-session","message":{"role":"assistant","content":[{"type":"text","text":"The auth middleware validates JWT tokens on each request using the refresh rotation pattern."}]},"cwd":"/tmp/test"}
+{"type":"user","uuid":"u2","timestamp":"2026-03-27T10:01:00Z","sessionId":"spike-session","message":{"role":"user","content":"We decided to add rate limiting to the login endpoint"},"cwd":"/tmp/test"}
+{"type":"assistant","uuid":"a2","timestamp":"2026-03-27T10:01:05Z","sessionId":"spike-session","message":{"role":"assistant","content":[{"type":"text","text":"Good call. I will add a sliding window rate limiter with 5 attempts per minute."}]},"cwd":"/tmp/test"}
+JSONL
+
+# ─────────────────────────────────────────────────────────────────
+echo "--- dry run ---"
+
+OUT=$(brane ingest-sessions "$FAKE_SESSION" -n 2>&1)
+if echo "$OUT" | grep -q "dry run"; then
+  pass "dry run prefix shown"
+else
+  fail "dry-run" "no dry run prefix: $OUT"
+fi
+
+if echo "$OUT" | grep -q "episodes"; then
+  pass "dry run shows episode count"
+else
+  fail "dry-run" "no episode count"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- actual ingestion ---"
+
+OUT2=$(brane ingest-sessions "$FAKE_SESSION" 2>&1)
+if echo "$OUT2" | grep -q "1 ingested"; then
+  pass "ingested 1 session"
+else
+  fail "ingest" "unexpected: $OUT2"
+fi
+
+if echo "$OUT2" | grep -q "episodes"; then
+  pass "shows episodes created"
+else
+  fail "episodes" "no episode info"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- dedup ---"
+
+OUT3=$(brane ingest-sessions "$FAKE_SESSION" 2>&1)
+if echo "$OUT3" | grep -q "0 ingested"; then
+  pass "dedup: 0 ingested on re-run"
+else
+  fail "dedup" "expected 0 ingested: $OUT3"
+fi
+
+if echo "$OUT3" | grep -q "skip"; then
+  pass "dedup: shows skip reason"
+else
+  fail "dedup" "no skip shown"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- directory mode ---"
+
+# Create a second session
+cat > "$FAKE_DIR/second-session.jsonl" << 'JSONL'
+{"type":"user","uuid":"u1","timestamp":"2026-03-27T11:00:00Z","sessionId":"second-session","message":{"role":"user","content":"What testing framework do we use?"},"cwd":"/tmp/test"}
+{"type":"assistant","uuid":"a1","timestamp":"2026-03-27T11:00:05Z","sessionId":"second-session","message":{"role":"assistant","content":[{"type":"text","text":"We use tc.ts, a language-agnostic JSON-in JSON-out test runner."}]},"cwd":"/tmp/test"}
+JSONL
+
+OUT4=$(brane ingest-sessions "$FAKE_DIR" 2>&1)
+if echo "$OUT4" | grep -q "found 2"; then
+  pass "directory mode finds 2 sessions"
+else
+  fail "dir" "unexpected: $OUT4"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- json mode ---"
+
+OUT5=$(brane ingest-sessions "$FAKE_DIR" -n -j 2>&1)
+if echo "$OUT5" | jq -e '.status == "success"' > /dev/null 2>&1; then
+  pass "JSON mode outputs valid result"
+else
+  fail "json" "invalid JSON: $OUT5"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- no sessions ---"
+
+EMPTY_DIR=$(mktemp -d)
+OUT6=$(brane ingest-sessions "$EMPTY_DIR" 2>&1)
+if echo "$OUT6" | grep -q "no session logs"; then
+  pass "empty dir shows no sessions message"
+else
+  fail "empty" "unexpected: $OUT6"
+fi
+rmdir "$EMPTY_DIR"
+
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+echo ""
+echo "  $PASS passed, $FAIL failed, $TOTAL total"
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo "  all tests passed!"
+else
+  echo "  FAILURES DETECTED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- `brane ingest-sessions [path] [--dry-run] [--limit N] [--json]`
- Auto-discovers sessions for current project or accepts explicit file/directory
- Progress output with session details, skip reasons, episode counts
- Dry run mode (`-n`) for preview

## Test plan
- [x] Spike: 9/9 tests pass (dry run, ingestion, dedup, directory mode, json, empty dir)
- [x] TC suite: 349/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)