### PR TITLE
Health dashboard: brane status command (#78)

### DIFF
--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,0 +1,144 @@
+//
+// status.ts - brane status dashboard
+//
+
+import { defineCommand } from "citty"
+import { sys } from "../../index.ts"
+import { resolve_lens_paths, get_active_lens } from "../../lib/state.ts"
+import { get_version } from "../../version.ts"
+import { output } from "../output.ts"
+import { existsSync, statSync } from "node:fs"
+
+function file_size(path: string): string {
+  try {
+    if (!existsSync(path)) return "-"
+    const bytes = statSync(path).size
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  } catch {
+    return "-"
+  }
+}
+
+export const status = defineCommand({
+  meta: {
+    name: "status",
+    description: "Show brane status: lens, schema, concepts, episodes, disk usage",
+  },
+  args: {
+    json: { type: "boolean", alias: "j", description: "Output as JSON" },
+  },
+  async run({ args }) {
+    // Gather data
+    const version = get_version()
+    let lens_name = "default"
+    let body_db = ""
+    let mind_db = ""
+    let brane_path = ""
+
+    try {
+      const paths = resolve_lens_paths()
+      lens_name = paths.lens_name
+      body_db = paths.body_db_path
+      mind_db = paths.mind_db_path
+      brane_path = paths.brane_path
+    } catch {
+      // Not initialized
+    }
+
+    // Graph summary
+    const summary_result = await sys.call("/graph/summary", {})
+    const summary = summary_result.status === "success"
+      ? summary_result.result as {
+          concepts?: { total?: number; by_type?: Record<string, number> }
+          edges?: { total?: number; by_relation?: Record<string, number> }
+        }
+      : null
+
+    // Episode count
+    const episodes_result = await sys.call("/mind/episodes/list", { limit: 5 })
+    const episodes_data = episodes_result.status === "success"
+      ? episodes_result.result as { episodes?: { id: number; observation: string; tags: string[]; timestamp: string }[] }
+      : null
+
+    // Schema version — read from mind.db directly (avoid init side effects)
+    let schema_version = "?"
+    try {
+      const { open_mind, is_mind_error } = await import("../../lib/mind.ts")
+      const mind = await open_mind()
+      if (!is_mind_error(mind)) {
+        try {
+          const rows = await mind.db.run("?[value] := *schema_meta['schema_version', value]")
+          if (rows.rows?.length > 0) {
+            schema_version = String(rows.rows[0][0])
+          }
+        } catch {}
+        mind.db.close()
+      }
+    } catch {}
+
+    const status_data = {
+      version,
+      lens: lens_name,
+      brane_path,
+      body_db_size: file_size(body_db),
+      mind_db_size: file_size(mind_db),
+      schema_version,
+      total_concepts: summary?.concepts?.total ?? 0,
+      total_edges: summary?.edges?.total ?? 0,
+      concepts_by_type: summary?.concepts?.by_type ?? {},
+      edges_by_relation: summary?.edges?.by_relation ?? {},
+      recent_episodes: (episodes_data?.episodes ?? []).slice(0, 5).map(ep => ({
+        id: ep.id,
+        timestamp: ep.timestamp,
+        observation: ep.observation.length > 80 ? ep.observation.slice(0, 80) + "..." : ep.observation,
+        tags: ep.tags,
+      })),
+    }
+
+    if (args.json) {
+      console.log(JSON.stringify({ status: "success", result: status_data }, null, 2))
+      return
+    }
+
+    // Pretty print
+    console.log(`brane ${version}`)
+    console.log("")
+    console.log(`  Lens:     ${lens_name}`)
+    console.log(`  Path:     ${brane_path || "(not initialized)"}`)
+    console.log(`  Schema:   ${schema_version}`)
+    console.log(`  Body DB:  ${file_size(body_db)}`)
+    console.log(`  Mind DB:  ${file_size(mind_db)}`)
+    console.log("")
+
+    const tc = status_data.total_concepts
+    const te = status_data.total_edges
+    console.log(`  Concepts: ${tc}`)
+
+    const types = status_data.concepts_by_type
+    if (Object.keys(types).length > 0) {
+      const type_parts = Object.entries(types).map(([t, n]) => `${t}: ${n}`).join(", ")
+      console.log(`            ${type_parts}`)
+    }
+
+    console.log(`  Edges:    ${te}`)
+
+    const rels = status_data.edges_by_relation
+    if (Object.keys(rels).length > 0) {
+      const rel_parts = Object.entries(rels).map(([r, n]) => `${r}: ${n}`).join(", ")
+      console.log(`            ${rel_parts}`)
+    }
+
+    const recent = status_data.recent_episodes
+    if (recent.length > 0) {
+      console.log("")
+      console.log(`  Recent memories (${recent.length}):`)
+      for (const ep of recent) {
+        const tags = ep.tags?.length > 0 ? ` [${ep.tags.join(", ")}]` : ""
+        const ts = ep.timestamp.slice(0, 10)
+        console.log(`    #${ep.id}  ${ts}  ${ep.observation}${tags}`)
+      }
+    }
+  },
+})

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -24,6 +24,7 @@ import { graph } from "./commands/graph.ts"
 import { prune } from "./commands/prune.ts"
 import { memory } from "./commands/memory.ts"
 import { ingestSessions } from "./commands/ingest-sessions.ts"
+import { status } from "./commands/status.ts"
 
 export const main = defineCommand({
   meta: {
@@ -34,6 +35,7 @@ export const main = defineCommand({
   subCommands: {
     // Convenience commands (most used)
     init,
+    status,
     ingest,
     search,
     verify,

--- a/try/status-dashboard-spike.sh
+++ b/try/status-dashboard-spike.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: Status Dashboard (#58)
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+brane() { (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" "$@"); }
+
+echo "=== Status Dashboard Spike ==="
+echo ""
+
+# Setup
+brane init > /dev/null 2>&1
+
+# ─────────────────────────────────────────────────────────────────
+echo "--- empty graph ---"
+
+OUT=$(brane status 2>&1)
+if echo "$OUT" | grep -q "brane"; then
+  pass "shows brane version"
+else
+  fail "version" "no version: $OUT"
+fi
+
+if echo "$OUT" | grep -q "Lens:"; then
+  pass "shows active lens"
+else
+  fail "lens" "no lens info"
+fi
+
+if echo "$OUT" | grep -q "Schema:"; then
+  pass "shows schema version"
+else
+  fail "schema" "no schema"
+fi
+
+if echo "$OUT" | grep -q "Body DB:"; then
+  pass "shows body DB size"
+else
+  fail "body" "no body DB size"
+fi
+
+if echo "$OUT" | grep -q "Mind DB:"; then
+  pass "shows mind DB size"
+else
+  fail "mind" "no mind DB size"
+fi
+
+if echo "$OUT" | grep -q "Concepts:"; then
+  pass "shows concept count"
+else
+  fail "concepts" "no concept count"
+fi
+
+if echo "$OUT" | grep -q "Edges:"; then
+  pass "shows edge count"
+else
+  fail "edges" "no edge count"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- with data ---"
+
+# Add some concepts and an episode
+echo '{"name": "AuthService", "type": "Entity"}' | brane /mind/concepts/create > /dev/null 2>&1
+echo '{"name": "UserDB", "type": "Entity"}' | brane /mind/concepts/create > /dev/null 2>&1
+echo '{"source": 1, "target": 2, "relation": "DEPENDS_ON"}' | brane /mind/edges/create > /dev/null 2>&1
+brane memory remember "Auth uses JWT tokens" > /dev/null 2>&1
+
+OUT2=$(brane status 2>&1)
+if echo "$OUT2" | grep -q "Concepts: 2"; then
+  pass "shows 2 concepts"
+else
+  fail "concepts" "expected 2 concepts: $OUT2"
+fi
+
+if echo "$OUT2" | grep -q "Edges:    1"; then
+  pass "shows 1 edge"
+else
+  fail "edges" "expected 1 edge"
+fi
+
+if echo "$OUT2" | grep -q "Entity: 2"; then
+  pass "shows concept type breakdown"
+else
+  fail "types" "no type breakdown"
+fi
+
+if echo "$OUT2" | grep -q "DEPENDS_ON: 1"; then
+  pass "shows edge relation breakdown"
+else
+  fail "rels" "no relation breakdown"
+fi
+
+if echo "$OUT2" | grep -q "Recent memories"; then
+  pass "shows recent memories"
+else
+  fail "recent" "no recent memories section"
+fi
+
+if echo "$OUT2" | grep -q "JWT"; then
+  pass "shows memory content"
+else
+  fail "content" "memory content not shown"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "--- json mode ---"
+
+JSON_OUT=$(brane status -j 2>&1)
+if echo "$JSON_OUT" | jq -e '.status == "success"' > /dev/null 2>&1; then
+  pass "JSON mode: valid result"
+else
+  fail "json" "invalid JSON"
+fi
+
+TC=$(echo "$JSON_OUT" | jq '.result.total_concepts' 2>/dev/null)
+if [ "$TC" = "2" ]; then
+  pass "JSON: total_concepts = 2"
+else
+  fail "json-concepts" "expected 2, got $TC"
+fi
+
+LENS=$(echo "$JSON_OUT" | jq -r '.result.lens' 2>/dev/null)
+if [ "$LENS" = "default" ]; then
+  pass "JSON: lens = default"
+else
+  fail "json-lens" "expected default, got $LENS"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+echo ""
+echo "  $PASS passed, $FAIL failed, $TOTAL total"
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo "  all tests passed!"
+else
+  echo "  FAILURES DETECTED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- `brane status` — one-screen overview of brane state
- Shows: version, lens, schema, DB sizes, concept/edge counts with type breakdowns, recent memories
- `brane status -j` for JSON output

## Test plan
- [x] Spike: 16/16 tests pass
- [x] TC suite: 349/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)