### PR TITLE
Ask: conversational synthesis over knowledge graph (#60)

### DIFF
--- a/dna/product/ROADMAP.md
+++ b/dna/product/ROADMAP.md
@@ -73,7 +73,7 @@ If stuck → Human checkpoint     ← Cannot make tests pass
 - [x] `060-ask` — Conversational synthesis over accumulated knowledge ([#83](https://github.com/ahoward/brane/issues/83))
 - [x] `061-storm` — Divergent exploration and idea generation ([#84](https://github.com/ahoward/brane/issues/84))
 - [x] `062-enhance` — Convergent refinement of existing knowledge ([#85](https://github.com/ahoward/brane/issues/85))
-- [ ] `063-active-lenses` — Lens prompts that shape LLM extraction ([#86](https://github.com/ahoward/brane/issues/86))
+- [x] `063-active-lenses` — Lens prompts that shape LLM extraction ([#86](https://github.com/ahoward/brane/issues/86))
 - [ ] `064-loop` — Autonomous goal-directed research ([#87](https://github.com/ahoward/brane/issues/87))
 - [ ] `065-rebuild` — Re-extract all sources through current lenses ([#88](https://github.com/ahoward/brane/issues/88))
 - [ ] `066-tldr` — Knowledge outline with synopses ([#89](https://github.com/ahoward/brane/issues/89))

--- a/dna/product/ROADMAP.md
+++ b/dna/product/ROADMAP.md
@@ -70,7 +70,7 @@ If stuck → Human checkpoint     ← Cannot make tests pass
 ### Next — Cognitive Layer (subsume bny brane)
 
 - [ ] `059-digest` — Consume URLs, files, directories, stdin into knowledge graph ([#82](https://github.com/ahoward/brane/issues/82))
-- [ ] `060-ask` — Conversational synthesis over accumulated knowledge ([#83](https://github.com/ahoward/brane/issues/83))
+- [x] `060-ask` — Conversational synthesis over accumulated knowledge ([#83](https://github.com/ahoward/brane/issues/83))
 - [ ] `061-storm` — Divergent exploration and idea generation ([#84](https://github.com/ahoward/brane/issues/84))
 - [ ] `062-enhance` — Convergent refinement of existing knowledge ([#85](https://github.com/ahoward/brane/issues/85))
 - [ ] `063-active-lenses` — Lens prompts that shape LLM extraction ([#86](https://github.com/ahoward/brane/issues/86))

--- a/dna/product/ROADMAP.md
+++ b/dna/product/ROADMAP.md
@@ -74,7 +74,7 @@ If stuck → Human checkpoint     ← Cannot make tests pass
 - [x] `061-storm` — Divergent exploration and idea generation ([#84](https://github.com/ahoward/brane/issues/84))
 - [x] `062-enhance` — Convergent refinement of existing knowledge ([#85](https://github.com/ahoward/brane/issues/85))
 - [x] `063-active-lenses` — Lens prompts that shape LLM extraction ([#86](https://github.com/ahoward/brane/issues/86))
-- [ ] `064-loop` — Autonomous goal-directed research ([#87](https://github.com/ahoward/brane/issues/87))
+- [x] `064-loop` — Autonomous goal-directed research ([#87](https://github.com/ahoward/brane/issues/87))
 - [ ] `065-rebuild` — Re-extract all sources through current lenses ([#88](https://github.com/ahoward/brane/issues/88))
 - [ ] `066-tldr` — Knowledge outline with synopses ([#89](https://github.com/ahoward/brane/issues/89))
 

--- a/dna/product/ROADMAP.md
+++ b/dna/product/ROADMAP.md
@@ -71,7 +71,7 @@ If stuck → Human checkpoint     ← Cannot make tests pass
 
 - [ ] `059-digest` — Consume URLs, files, directories, stdin into knowledge graph ([#82](https://github.com/ahoward/brane/issues/82))
 - [x] `060-ask` — Conversational synthesis over accumulated knowledge ([#83](https://github.com/ahoward/brane/issues/83))
-- [ ] `061-storm` — Divergent exploration and idea generation ([#84](https://github.com/ahoward/brane/issues/84))
+- [x] `061-storm` — Divergent exploration and idea generation ([#84](https://github.com/ahoward/brane/issues/84))
 - [ ] `062-enhance` — Convergent refinement of existing knowledge ([#85](https://github.com/ahoward/brane/issues/85))
 - [ ] `063-active-lenses` — Lens prompts that shape LLM extraction ([#86](https://github.com/ahoward/brane/issues/86))
 - [ ] `064-loop` — Autonomous goal-directed research ([#87](https://github.com/ahoward/brane/issues/87))

--- a/dna/product/ROADMAP.md
+++ b/dna/product/ROADMAP.md
@@ -76,7 +76,7 @@ If stuck → Human checkpoint     ← Cannot make tests pass
 - [x] `063-active-lenses` — Lens prompts that shape LLM extraction ([#86](https://github.com/ahoward/brane/issues/86))
 - [x] `064-loop` — Autonomous goal-directed research ([#87](https://github.com/ahoward/brane/issues/87))
 - [x] `065-rebuild` — Re-extract all sources through current lenses ([#88](https://github.com/ahoward/brane/issues/88))
-- [ ] `066-tldr` — Knowledge outline with synopses ([#89](https://github.com/ahoward/brane/issues/89))
+- [x] `066-tldr` — Knowledge outline with synopses ([#89](https://github.com/ahoward/brane/issues/89))
 
 ### Deferred
 

--- a/dna/product/ROADMAP.md
+++ b/dna/product/ROADMAP.md
@@ -69,7 +69,7 @@ If stuck → Human checkpoint     ← Cannot make tests pass
 
 ### Next — Cognitive Layer (subsume bny brane)
 
-- [ ] `059-digest` — Consume URLs, files, directories, stdin into knowledge graph ([#82](https://github.com/ahoward/brane/issues/82))
+- [x] `059-digest` — Consume URLs, files, directories, stdin into knowledge graph ([#82](https://github.com/ahoward/brane/issues/82))
 - [x] `060-ask` — Conversational synthesis over accumulated knowledge ([#83](https://github.com/ahoward/brane/issues/83))
 - [x] `061-storm` — Divergent exploration and idea generation ([#84](https://github.com/ahoward/brane/issues/84))
 - [x] `062-enhance` — Convergent refinement of existing knowledge ([#85](https://github.com/ahoward/brane/issues/85))

--- a/dna/product/ROADMAP.md
+++ b/dna/product/ROADMAP.md
@@ -72,7 +72,7 @@ If stuck → Human checkpoint     ← Cannot make tests pass
 - [ ] `059-digest` — Consume URLs, files, directories, stdin into knowledge graph ([#82](https://github.com/ahoward/brane/issues/82))
 - [x] `060-ask` — Conversational synthesis over accumulated knowledge ([#83](https://github.com/ahoward/brane/issues/83))
 - [x] `061-storm` — Divergent exploration and idea generation ([#84](https://github.com/ahoward/brane/issues/84))
-- [ ] `062-enhance` — Convergent refinement of existing knowledge ([#85](https://github.com/ahoward/brane/issues/85))
+- [x] `062-enhance` — Convergent refinement of existing knowledge ([#85](https://github.com/ahoward/brane/issues/85))
 - [ ] `063-active-lenses` — Lens prompts that shape LLM extraction ([#86](https://github.com/ahoward/brane/issues/86))
 - [ ] `064-loop` — Autonomous goal-directed research ([#87](https://github.com/ahoward/brane/issues/87))
 - [ ] `065-rebuild` — Re-extract all sources through current lenses ([#88](https://github.com/ahoward/brane/issues/88))

--- a/dna/product/ROADMAP.md
+++ b/dna/product/ROADMAP.md
@@ -75,7 +75,7 @@ If stuck → Human checkpoint     ← Cannot make tests pass
 - [x] `062-enhance` — Convergent refinement of existing knowledge ([#85](https://github.com/ahoward/brane/issues/85))
 - [x] `063-active-lenses` — Lens prompts that shape LLM extraction ([#86](https://github.com/ahoward/brane/issues/86))
 - [x] `064-loop` — Autonomous goal-directed research ([#87](https://github.com/ahoward/brane/issues/87))
-- [ ] `065-rebuild` — Re-extract all sources through current lenses ([#88](https://github.com/ahoward/brane/issues/88))
+- [x] `065-rebuild` — Re-extract all sources through current lenses ([#88](https://github.com/ahoward/brane/issues/88))
 - [ ] `066-tldr` — Knowledge outline with synopses ([#89](https://github.com/ahoward/brane/issues/89))
 
 ### Deferred

--- a/src/cli/commands/ask.ts
+++ b/src/cli/commands/ask.ts
@@ -1,0 +1,75 @@
+//
+// ask.ts - CLI command: brane ask <question>
+//
+// Synthesize an answer from accumulated knowledge.
+//
+
+import { defineCommand } from "citty"
+import { sys } from "../../index.ts"
+import { output } from "../output.ts"
+
+export const ask = defineCommand({
+  meta: {
+    name: "ask",
+    description: "Ask a question — get a synthesized answer from the knowledge graph",
+  },
+  args: {
+    question: { type: "positional", description: "What you want to know", required: true },
+    limit:    { type: "string", alias: "l", description: "Max context items to load (default: 20)" },
+    agent:    { type: "string", alias: "a", description: "Filter by agent ID" },
+    after:    { type: "string", description: "Only use knowledge after this ISO timestamp" },
+    before:   { type: "string", description: "Only use knowledge before this ISO timestamp" },
+    lens:     { type: "string", description: "Lens prompt to shape the answer" },
+    json:     { type: "boolean", alias: "j", description: "Output as JSON" },
+  },
+  async run({ args }) {
+    const params: Record<string, unknown> = {
+      question: args.question,
+    }
+    if (args.limit) params.limit = parseInt(String(args.limit), 10) || 20
+    if (args.agent) params.agent_id = args.agent
+    if (args.after) params.after = args.after
+    if (args.before) params.before = args.before
+    if (args.lens) params.lens = args.lens
+
+    const result = await sys.call("/calabi/ask", params)
+
+    if (args.json) {
+      output(result, { json: true })
+      return
+    }
+
+    if (result.status === "error") {
+      output(result, {})
+      return
+    }
+
+    const data = result.result as {
+      answer: string
+      citations: { concept_ids: number[]; episode_ids: number[]; edge_ids: number[] }
+      context_loaded: { concepts: number; episodes: number; edges: number }
+    }
+
+    if (!data) return
+
+    // Print the answer
+    console.log(data.answer)
+
+    // Print citations
+    const c = data.citations
+    const cited = [
+      ...(c.concept_ids?.length ? [`concepts: ${c.concept_ids.map(id => `#${id}`).join(", ")}`] : []),
+      ...(c.episode_ids?.length ? [`episodes: ${c.episode_ids.map(id => `#${id}`).join(", ")}`] : []),
+      ...(c.edge_ids?.length ? [`edges: ${c.edge_ids.map(id => `#${id}`).join(", ")}`] : []),
+    ]
+
+    if (cited.length > 0) {
+      console.log("")
+      console.log(`sources: ${cited.join("; ")}`)
+    }
+
+    // Context stats
+    const ctx = data.context_loaded
+    console.log(`(${ctx.concepts} concepts, ${ctx.episodes} episodes, ${ctx.edges} edges searched)`)
+  },
+})

--- a/src/cli/commands/enhance.ts
+++ b/src/cli/commands/enhance.ts
@@ -1,0 +1,74 @@
+//
+// enhance.ts - CLI command: brane enhance [focus]
+//
+// Convergent refinement of existing knowledge.
+//
+
+import { defineCommand } from "citty"
+import { sys } from "../../index.ts"
+import { output } from "../output.ts"
+
+export const enhance = defineCommand({
+  meta: {
+    name: "enhance",
+    description: "Refine knowledge — merge duplicates, add missing edges, surface contradictions",
+  },
+  args: {
+    focus:  { type: "positional", description: "Topic to focus refinement on", required: false },
+    rounds: { type: "string", alias: "r", description: "Iterative refinement rounds (default: 1, max: 5)" },
+    limit:  { type: "string", alias: "l", description: "Max context items (default: 30)" },
+    agent:  { type: "string", alias: "a", description: "Agent ID for created items" },
+    "dry-run": { type: "boolean", alias: "n", description: "Preview without writing" },
+    json:   { type: "boolean", alias: "j", description: "Output as JSON" },
+  },
+  async run({ args }) {
+    const params: Record<string, unknown> = {}
+    if (args.focus) params.focus = args.focus
+    if (args.rounds) params.rounds = parseInt(String(args.rounds), 10) || 1
+    if (args.limit) params.limit = parseInt(String(args.limit), 10) || 30
+    if (args.agent) params.agent_id = args.agent
+    if (args["dry-run"]) params.dry_run = true
+
+    const result = await sys.call("/calabi/enhance", params)
+
+    if (args.json) {
+      output(result, { json: true })
+      return
+    }
+
+    if (result.status === "error") {
+      output(result, {})
+      return
+    }
+
+    const data = result.result as {
+      rounds_completed: number
+      total_merges: number
+      total_edges: number
+      total_observations: number
+      rounds: { round: number; merges_applied: number; edges_created: number; observations_added: number; reasoning: string }[]
+      dry_run: boolean
+    }
+
+    if (!data) return
+
+    const prefix = data.dry_run ? "[dry-run] " : ""
+
+    if (data.rounds_completed === 0) {
+      console.log("Nothing to refine — knowledge graph is empty.")
+      return
+    }
+
+    for (const r of data.rounds) {
+      if (data.rounds.length > 1) {
+        console.log(`\n--- Round ${r.round} ---`)
+      }
+      console.log(r.reasoning)
+      console.log("")
+      console.log(`  ${prefix}${r.merges_applied} merges, +${r.edges_created} edges, +${r.observations_added} observations`)
+    }
+
+    console.log("")
+    console.log(`${prefix}${data.rounds_completed} round(s): ${data.total_merges} merges, +${data.total_edges} edges, +${data.total_observations} observations`)
+  },
+})

--- a/src/cli/commands/lens.ts
+++ b/src/cli/commands/lens.ts
@@ -16,6 +16,8 @@ export const lens = defineCommand({
       meta: { name: "create", description: "Create a new named lens" },
       args: {
         name: { type: "positional", description: "Lens name", required: true },
+        prompt: { type: "string", alias: "p", description: "Lens prompt (cognitive filter for extraction)" },
+        description: { type: "string", alias: "d", description: "Description of the lens" },
         config: { type: "string", alias: "c", description: "YAML config file to pre-load" },
         json: { type: "boolean", alias: "j", description: "Output as JSON" },
       },
@@ -25,14 +27,30 @@ export const lens = defineCommand({
 
         const result = await sys.call("/lens/create", params)
 
+        if (result.status !== "success") {
+          if (args.json) { output(result, { json: true }) } else { output(result, {}) }
+          return
+        }
+
+        // If --prompt was provided, save the lens prompt
+        if (args.prompt) {
+          await sys.call("/lens/prompt", {
+            action: "set",
+            name: args.name,
+            prompt: args.prompt,
+            description: args.description ?? "",
+          })
+        }
+
         if (args.json) {
           output(result, { json: true })
-        } else if (result.status === "success" && result.result) {
+        } else {
           const r = result.result as any
           console.log(`created ${r.path}/body.db`)
           console.log(`created ${r.path}/mind.db`)
-        } else {
-          output(result, {})
+          if (args.prompt) {
+            console.log(`prompt: ${args.prompt.slice(0, 60)}${args.prompt.length > 60 ? "..." : ""}`)
+          }
         }
       },
     }),
@@ -281,6 +299,82 @@ export const lens = defineCommand({
           }
         } else {
           output(result, {})
+        }
+      },
+    }),
+
+    on: defineCommand({
+      meta: { name: "on", description: "Activate a lens prompt (shapes future digest/storm/enhance/ask)" },
+      args: {
+        name: { type: "positional", description: "Lens prompt name", required: true },
+        json: { type: "boolean", alias: "j", description: "Output as JSON" },
+      },
+      async run({ args }) {
+        const result = await sys.call("/lens/prompt", { action: "on", name: args.name })
+        if (args.json) {
+          output(result, { json: true })
+        } else if (result.status === "success") {
+          console.log(`activated lens: ${args.name}`)
+        } else {
+          output(result, {})
+        }
+      },
+    }),
+
+    off: defineCommand({
+      meta: { name: "off", description: "Deactivate a lens prompt" },
+      args: {
+        name: { type: "positional", description: "Lens prompt name", required: true },
+        json: { type: "boolean", alias: "j", description: "Output as JSON" },
+      },
+      async run({ args }) {
+        const result = await sys.call("/lens/prompt", { action: "off", name: args.name })
+        if (args.json) {
+          output(result, { json: true })
+        } else if (result.status === "success") {
+          console.log(`deactivated lens: ${args.name}`)
+        } else {
+          output(result, {})
+        }
+      },
+    }),
+
+    prompt: defineCommand({
+      meta: { name: "prompt", description: "Set or view a lens prompt" },
+      args: {
+        name: { type: "positional", description: "Lens prompt name", required: true },
+        set: { type: "string", alias: "s", description: "Set the prompt text" },
+        description: { type: "string", alias: "d", description: "Lens description" },
+        json: { type: "boolean", alias: "j", description: "Output as JSON" },
+      },
+      async run({ args }) {
+        if (args.set) {
+          const result = await sys.call("/lens/prompt", {
+            action: "set",
+            name: args.name,
+            prompt: args.set,
+            description: args.description ?? "",
+          })
+          if (args.json) {
+            output(result, { json: true })
+          } else if (result.status === "success") {
+            console.log(`saved lens prompt: ${args.name}`)
+          } else {
+            output(result, {})
+          }
+        } else {
+          const result = await sys.call("/lens/prompt", { action: "get", name: args.name })
+          if (args.json) {
+            output(result, { json: true })
+          } else if (result.status === "success" && result.result) {
+            const r = result.result as { name: string; prompt: string; description: string; active: boolean }
+            console.log(`Name: ${r.name}`)
+            console.log(`Active: ${r.active ? "yes" : "no"}`)
+            if (r.description) console.log(`Description: ${r.description}`)
+            console.log(`Prompt: ${r.prompt}`)
+          } else {
+            output(result, {})
+          }
         }
       },
     }),

--- a/src/cli/commands/loop.ts
+++ b/src/cli/commands/loop.ts
@@ -1,0 +1,129 @@
+//
+// loop.ts - CLI command: brane loop <goal>
+//
+// Autonomous goal-directed research.
+//
+
+import { defineCommand } from "citty"
+import { sys } from "../../index.ts"
+import { output } from "../output.ts"
+
+const loopRun = defineCommand({
+  meta: {
+    name: "run",
+    description: "Start or resume an autonomous research loop",
+  },
+  args: {
+    goal:    { type: "positional", description: "Research goal", required: false },
+    rounds:  { type: "string", alias: "r", description: "Max rounds (default: 5, max: 10)" },
+    resume:  { type: "string", description: "Resume a paused loop by ID" },
+    agent:   { type: "string", alias: "a", description: "Agent ID" },
+    "dry-run": { type: "boolean", alias: "n", description: "Preview without searching/digesting" },
+    json:    { type: "boolean", alias: "j", description: "Output as JSON" },
+  },
+  async run({ args }) {
+    const params: Record<string, unknown> = {}
+    if (args.goal) params.goal = args.goal
+    if (args.rounds) params.rounds = parseInt(String(args.rounds), 10) || 5
+    if (args.resume) params.resume = args.resume
+    if (args.agent) params.agent_id = args.agent
+    if (args["dry-run"]) params.dry_run = true
+
+    if (!args.goal && !args.resume) {
+      console.error("error: goal is required (or --resume <id>)")
+      process.exit(1)
+    }
+
+    const result = await sys.call("/calabi/loop", params)
+
+    if (args.json) {
+      output(result, { json: true })
+      return
+    }
+
+    if (result.status === "error") {
+      output(result, {})
+      return
+    }
+
+    const data = result.result as {
+      id: string
+      goal: string
+      status: string
+      rounds_completed: number
+      rounds: { round: number; assessment: string; gaps: string[]; queries_searched: string[]; urls_fetched: string[]; sources_digested: number; converging: boolean }[]
+      dry_run: boolean
+    }
+
+    if (!data) return
+
+    const prefix = data.dry_run ? "[dry-run] " : ""
+    console.log(`${prefix}loop ${data.id}: ${data.goal}`)
+    console.log("")
+
+    for (const r of data.rounds) {
+      console.log(`--- Round ${r.round} ${r.converging ? "(converging)" : ""} ---`)
+      console.log(r.assessment)
+      if (r.gaps.length > 0) {
+        console.log(`  gaps: ${r.gaps.join("; ")}`)
+      }
+      if (r.queries_searched.length > 0) {
+        console.log(`  searched: ${r.queries_searched.join(", ")}`)
+      }
+      if (r.urls_fetched.length > 0) {
+        console.log(`  fetched: ${r.urls_fetched.length} URLs`)
+      }
+      if (r.sources_digested > 0) {
+        console.log(`  digested: ${r.sources_digested} sources`)
+      }
+      console.log("")
+    }
+
+    console.log(`${prefix}status: ${data.status} (${data.rounds_completed} rounds)`)
+  },
+})
+
+const loopList = defineCommand({
+  meta: {
+    name: "list",
+    description: "List all research loops",
+  },
+  args: {
+    json: { type: "boolean", alias: "j", description: "Output as JSON" },
+  },
+  async run({ args }) {
+    const result = await sys.call("/calabi/loop", { action: "list" })
+
+    if (args.json) {
+      output(result, { json: true })
+      return
+    }
+
+    if (result.status === "error") {
+      output(result, {})
+      return
+    }
+
+    const data = result.result as { loops: { id: string; goal: string; status: string; rounds_completed: number; max_rounds: number; updated_at: string }[] }
+    if (!data?.loops?.length) {
+      console.log("No loops yet.")
+      return
+    }
+
+    for (const l of data.loops) {
+      const status = l.status.padEnd(10)
+      console.log(`${l.id}  ${status}  ${l.rounds_completed}/${l.max_rounds} rounds  ${l.goal.slice(0, 50)}`)
+    }
+  },
+})
+
+export const loop = defineCommand({
+  meta: {
+    name: "loop",
+    description: "Autonomous goal-directed research (reflect → search → digest → repeat)",
+  },
+  subCommands: {
+    run: loopRun,
+    list: loopList,
+  },
+})

--- a/src/cli/commands/rebuild.ts
+++ b/src/cli/commands/rebuild.ts
@@ -1,0 +1,67 @@
+//
+// rebuild.ts - CLI command: brane rebuild
+//
+// Re-extract all sources through current lenses.
+//
+
+import { defineCommand } from "citty"
+import { sys } from "../../index.ts"
+import { output } from "../output.ts"
+
+export const rebuild = defineCommand({
+  meta: {
+    name: "rebuild",
+    description: "Re-extract all digested sources through current active lenses",
+  },
+  args: {
+    lens:      { type: "string", alias: "l", description: "Override lens prompt for rebuild" },
+    agent:     { type: "string", alias: "a", description: "Agent ID" },
+    "dry-run": { type: "boolean", alias: "n", description: "Show what would be rebuilt" },
+    json:      { type: "boolean", alias: "j", description: "Output as JSON" },
+  },
+  async run({ args }) {
+    const params: Record<string, unknown> = {}
+    if (args.lens) params.lens = args.lens
+    if (args.agent) params.agent_id = args.agent
+    if (args["dry-run"]) params.dry_run = true
+
+    const result = await sys.call("/calabi/rebuild", params)
+
+    if (args.json) {
+      output(result, { json: true })
+      return
+    }
+
+    if (result.status === "error") {
+      output(result, {})
+      return
+    }
+
+    const data = result.result as {
+      sources_total: number
+      sources_rebuilt: number
+      sources_skipped: number
+      sources_failed: number
+      details: { label: string; status: string; reason?: string }[]
+      dry_run: boolean
+    }
+
+    if (!data) return
+
+    const prefix = data.dry_run ? "[dry-run] " : ""
+
+    if (data.sources_total === 0) {
+      console.log("No digested sources to rebuild.")
+      return
+    }
+
+    for (const d of data.details) {
+      const icon = d.status === "rebuilt" ? "+" : d.status === "skipped" ? "-" : "!"
+      const reason = d.reason ? ` (${d.reason})` : ""
+      console.log(`  ${icon} ${d.label}${reason}`)
+    }
+
+    console.log("")
+    console.log(`${prefix}${data.sources_total} sources: ${data.sources_rebuilt} rebuilt, ${data.sources_skipped} skipped, ${data.sources_failed} failed`)
+  },
+})

--- a/src/cli/commands/storm.ts
+++ b/src/cli/commands/storm.ts
@@ -1,0 +1,85 @@
+//
+// storm.ts - CLI command: brane storm [seed]
+//
+// Divergent brainstorming over accumulated knowledge.
+//
+
+import { defineCommand } from "citty"
+import { sys } from "../../index.ts"
+import { output } from "../output.ts"
+
+export const storm = defineCommand({
+  meta: {
+    name: "storm",
+    description: "Brainstorm — find gaps, connections, and blind spots in your knowledge",
+  },
+  args: {
+    seed:   { type: "positional", description: "Optional topic to seed brainstorming", required: false },
+    input:  { type: "string", alias: "i", description: "File to brainstorm against" },
+    rounds: { type: "string", alias: "r", description: "Iterative deepening rounds (default: 1, max: 5)" },
+    limit:  { type: "string", alias: "l", description: "Max context items per round (default: 20)" },
+    agent:  { type: "string", alias: "a", description: "Agent ID for created items" },
+    "dry-run": { type: "boolean", alias: "n", description: "Preview without writing to graph" },
+    json:   { type: "boolean", alias: "j", description: "Output as JSON" },
+  },
+  async run({ args }) {
+    const params: Record<string, unknown> = {}
+    if (args.seed) params.seed = args.seed
+    if (args.input) params.input = args.input
+    if (args.rounds) params.rounds = parseInt(String(args.rounds), 10) || 1
+    if (args.limit) params.limit = parseInt(String(args.limit), 10) || 20
+    if (args.agent) params.agent_id = args.agent
+    if (args["dry-run"]) params.dry_run = true
+
+    const result = await sys.call("/calabi/storm", params)
+
+    if (args.json) {
+      output(result, { json: true })
+      return
+    }
+
+    if (result.status === "error") {
+      output(result, {})
+      return
+    }
+
+    const data = result.result as {
+      rounds_completed: number
+      total_concepts: number
+      total_edges: number
+      total_episodes: number
+      suggestions: { kind: string; value: string; reason: string }[]
+      rounds: { round: number; concepts_created: number; edges_created: number; episodes_created: number; suggestions: { kind: string; value: string; reason: string }[]; reasoning: string }[]
+      dry_run: boolean
+    }
+
+    if (!data) return
+
+    const prefix = data.dry_run ? "[dry-run] " : ""
+
+    // Print per-round results
+    for (const r of data.rounds) {
+      if (data.rounds.length > 1) {
+        console.log(`\n--- Round ${r.round} ---`)
+      }
+      console.log(r.reasoning)
+      console.log("")
+      console.log(`  ${prefix}+${r.concepts_created} concepts, +${r.edges_created} edges, +${r.episodes_created} episodes`)
+    }
+
+    // Print suggestions
+    if (data.suggestions.length > 0) {
+      console.log("")
+      console.log("Suggestions:")
+      for (const s of data.suggestions) {
+        const icon = s.kind === "question" ? "?" : s.kind === "source" ? ">" : "*"
+        console.log(`  ${icon} [${s.kind}] ${s.value}`)
+        console.log(`    ${s.reason}`)
+      }
+    }
+
+    // Summary
+    console.log("")
+    console.log(`${prefix}${data.rounds_completed} round(s): +${data.total_concepts} concepts, +${data.total_edges} edges, +${data.total_episodes} episodes, ${data.suggestions.length} suggestions`)
+  },
+})

--- a/src/cli/commands/tldr.ts
+++ b/src/cli/commands/tldr.ts
@@ -1,0 +1,69 @@
+//
+// tldr.ts - CLI command: brane tldr
+//
+// Knowledge outline with synopses.
+//
+
+import { defineCommand } from "citty"
+import { sys } from "../../index.ts"
+import { output } from "../output.ts"
+
+export const tldr = defineCommand({
+  meta: {
+    name: "tldr",
+    description: "Show a structured outline of what brane knows",
+  },
+  args: {
+    focus: { type: "string", alias: "f", description: "Focus on a topic area" },
+    limit: { type: "string", alias: "l", description: "Max items to load (default: 50)" },
+    json:  { type: "boolean", alias: "j", description: "Output as JSON" },
+  },
+  async run({ args }) {
+    const params: Record<string, unknown> = {}
+    if (args.focus) params.focus = args.focus
+    if (args.limit) params.limit = parseInt(String(args.limit), 10) || 50
+
+    const result = await sys.call("/calabi/tldr", params)
+
+    if (args.json) {
+      output(result, { json: true })
+      return
+    }
+
+    if (result.status === "error") {
+      output(result, {})
+      return
+    }
+
+    const data = result.result as {
+      topics: { title: string; items: string[] }[]
+      learnings: string[]
+      stats: { concepts: number; edges: number; episodes: number; topics: number }
+    }
+
+    if (!data) return
+
+    if (data.topics.length === 0 && data.learnings.length === 0) {
+      console.log("Nothing to summarize — knowledge graph is empty.")
+      return
+    }
+
+    for (const topic of data.topics) {
+      console.log(`\n## ${topic.title}`)
+      for (const item of topic.items) {
+        console.log(`- ${item}`)
+      }
+    }
+
+    if (data.learnings.length > 0) {
+      console.log("\n## Recent Learnings")
+      for (const l of data.learnings) {
+        console.log(`- ${l}`)
+      }
+    }
+
+    console.log("")
+    const s = data.stats
+    console.log(`${s.topics} topics, ${s.concepts} concepts, ${s.edges} edges, ${s.episodes} episodes`)
+  },
+})

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -29,6 +29,7 @@ import { ask } from "./commands/ask.ts"
 import { storm } from "./commands/storm.ts"
 import { enhance } from "./commands/enhance.ts"
 import { loop } from "./commands/loop.ts"
+import { rebuild } from "./commands/rebuild.ts"
 
 export const main = defineCommand({
   meta: {
@@ -45,6 +46,7 @@ export const main = defineCommand({
     storm,
     enhance,
     loop,
+    rebuild,
     search,
     verify,
     prune,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -25,6 +25,7 @@ import { memory } from "./commands/memory.ts"
 import { ingestSessions } from "./commands/ingest-sessions.ts"
 import { status } from "./commands/status.ts"
 import { digest } from "./commands/digest.ts"
+import { ask } from "./commands/ask.ts"
 
 export const main = defineCommand({
   meta: {
@@ -37,6 +38,7 @@ export const main = defineCommand({
     init,
     status,
     digest,
+    ask,
     search,
     verify,
     prune,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -27,6 +27,7 @@ import { status } from "./commands/status.ts"
 import { digest } from "./commands/digest.ts"
 import { ask } from "./commands/ask.ts"
 import { storm } from "./commands/storm.ts"
+import { enhance } from "./commands/enhance.ts"
 
 export const main = defineCommand({
   meta: {
@@ -41,6 +42,7 @@ export const main = defineCommand({
     digest,
     ask,
     storm,
+    enhance,
     search,
     verify,
     prune,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -30,6 +30,7 @@ import { storm } from "./commands/storm.ts"
 import { enhance } from "./commands/enhance.ts"
 import { loop } from "./commands/loop.ts"
 import { rebuild } from "./commands/rebuild.ts"
+import { tldr } from "./commands/tldr.ts"
 
 export const main = defineCommand({
   meta: {
@@ -47,6 +48,7 @@ export const main = defineCommand({
     enhance,
     loop,
     rebuild,
+    tldr,
     search,
     verify,
     prune,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -26,6 +26,7 @@ import { ingestSessions } from "./commands/ingest-sessions.ts"
 import { status } from "./commands/status.ts"
 import { digest } from "./commands/digest.ts"
 import { ask } from "./commands/ask.ts"
+import { storm } from "./commands/storm.ts"
 
 export const main = defineCommand({
   meta: {
@@ -39,6 +40,7 @@ export const main = defineCommand({
     status,
     digest,
     ask,
+    storm,
     search,
     verify,
     prune,
@@ -73,6 +75,7 @@ export const main = defineCommand({
 // Alias mapping for short commands
 export const subCommandAliases: Record<string, string> = {
   d: "digest",
+  s: "storm",
   c: "concept",
   e: "edge",
   r: "rule",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -28,6 +28,7 @@ import { digest } from "./commands/digest.ts"
 import { ask } from "./commands/ask.ts"
 import { storm } from "./commands/storm.ts"
 import { enhance } from "./commands/enhance.ts"
+import { loop } from "./commands/loop.ts"
 
 export const main = defineCommand({
   meta: {
@@ -43,6 +44,7 @@ export const main = defineCommand({
     ask,
     storm,
     enhance,
+    loop,
     search,
     verify,
     prune,

--- a/src/handlers/calabi/ask.ts
+++ b/src/handlers/calabi/ask.ts
@@ -11,6 +11,7 @@ import { ask_knowledge } from "../../lib/llm/ask.ts"
 import { consume_llm_call } from "../../lib/rate-limit.ts"
 import { is_mock_mode } from "../../lib/llm/index.ts"
 import { sys } from "../../index.ts"
+import { get_active_lens_prompts } from "../../lib/state.ts"
 
 interface AskParams {
   question:  string
@@ -45,7 +46,7 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<AskRe
   const question = p.question.trim()
   const limit = typeof p.limit === "number" && p.limit > 0 ? p.limit : 20
   const half = Math.ceil(limit / 2)
-  const lens_prompt = typeof p.lens === "string" && p.lens.trim() ? p.lens.trim() : undefined
+  const lens_prompt = typeof p.lens === "string" && p.lens.trim() ? p.lens.trim() : get_active_lens_prompts()
 
   emit?.("progress", { phase: "searching", question })
 

--- a/src/handlers/calabi/ask.ts
+++ b/src/handlers/calabi/ask.ts
@@ -1,0 +1,160 @@
+//
+// ask.ts - conversational synthesis over accumulated knowledge
+//
+// Vector-searches concepts + episodes for relevant context,
+// enriches with graph neighbors, sends to LLM for synthesis.
+//
+
+import type { Params, Result, Emit } from "../../lib/types.ts"
+import { success, error } from "../../lib/result.ts"
+import { ask_knowledge } from "../../lib/llm/ask.ts"
+import { consume_llm_call } from "../../lib/rate-limit.ts"
+import { is_mock_mode } from "../../lib/llm/index.ts"
+import { sys } from "../../index.ts"
+
+interface AskParams {
+  question:  string
+  limit?:    number     // max context items to load (default 20)
+  agent_id?: string     // filter by agent
+  after?:    string     // time range
+  before?:   string
+  lens?:     string     // lens prompt to shape the answer
+}
+
+interface AskResult {
+  answer:    string
+  citations: {
+    concept_ids: number[]
+    episode_ids: number[]
+    edge_ids:    number[]
+  }
+  context_loaded: {
+    concepts: number
+    episodes: number
+    edges:    number
+  }
+}
+
+export async function handler(params: Params, emit?: Emit): Promise<Result<AskResult>> {
+  const p = (params ?? {}) as AskParams
+
+  if (!p.question || typeof p.question !== "string" || !p.question.trim()) {
+    return error({ question: [{ code: "required", message: "question is required" }] })
+  }
+
+  const question = p.question.trim()
+  const limit = typeof p.limit === "number" && p.limit > 0 ? p.limit : 20
+  const half = Math.ceil(limit / 2)
+  const lens_prompt = typeof p.lens === "string" && p.lens.trim() ? p.lens.trim() : undefined
+
+  emit?.("progress", { phase: "searching", question })
+
+  // Step 1: Vector search for relevant concepts
+  const concept_params: Record<string, unknown> = { query: question, limit: half }
+  if (p.agent_id) concept_params.agent_id = p.agent_id
+  if (p.after) concept_params.after = p.after
+  if (p.before) concept_params.before = p.before
+
+  const concept_result = await sys.call("/mind/search", concept_params)
+  const concept_matches = concept_result.status === "success"
+    ? ((concept_result.result as any)?.matches ?? []) as { id: number; name: string; type: string; score: number }[]
+    : []
+
+  // Step 2: Vector search for relevant episodes
+  const episode_params: Record<string, unknown> = { query: question, limit: half }
+  if (p.agent_id) episode_params.agent_id = p.agent_id
+  if (p.after) episode_params.after = p.after
+  if (p.before) episode_params.before = p.before
+
+  const episode_result = await sys.call("/mind/episodes/search", episode_params)
+  const episode_matches = episode_result.status === "success"
+    ? ((episode_result.result as any)?.matches ?? []) as { id: number; observation: string; context?: string; tags?: string[]; score: number }[]
+    : []
+
+  // Step 3: Graph enrichment — get neighbors of matched concepts
+  emit?.("progress", { phase: "enriching" })
+
+  const seen_concept_ids = new Set(concept_matches.map(c => c.id))
+  const all_edges: { id: number; source_name: string; target_name: string; relation: string }[] = []
+  const neighbor_concepts: typeof concept_matches = []
+
+  for (const concept of concept_matches.slice(0, 5)) {  // limit neighbor lookups
+    const neighbors_result = await sys.call("/graph/neighbors", { id: concept.id })
+    if (neighbors_result.status !== "success") continue
+
+    const data = neighbors_result.result as any
+    const neighbors = data?.neighbors ?? {}
+
+    for (const n of (neighbors.incoming ?? [])) {
+      all_edges.push({
+        id: n.edge_id,
+        source_name: n.name,
+        target_name: concept.name,
+        relation: n.relation,
+      })
+      if (!seen_concept_ids.has(n.id)) {
+        seen_concept_ids.add(n.id)
+        neighbor_concepts.push({ id: n.id, name: n.name, type: n.type, score: 0 })
+      }
+    }
+
+    for (const n of (neighbors.outgoing ?? [])) {
+      all_edges.push({
+        id: n.edge_id,
+        source_name: concept.name,
+        target_name: n.name,
+        relation: n.relation,
+      })
+      if (!seen_concept_ids.has(n.id)) {
+        seen_concept_ids.add(n.id)
+        neighbor_concepts.push({ id: n.id, name: n.name, type: n.type, score: 0 })
+      }
+    }
+  }
+
+  // Combine direct matches + neighbors (direct matches first)
+  const all_concepts = [...concept_matches, ...neighbor_concepts]
+
+  // If we have nothing at all, return early
+  if (all_concepts.length === 0 && episode_matches.length === 0) {
+    return success({
+      answer: "I don't have any relevant knowledge to answer this question. Try digesting some content first with `brane digest`.",
+      citations: { concept_ids: [], episode_ids: [], edge_ids: [] },
+      context_loaded: { concepts: 0, episodes: 0, edges: 0 },
+    })
+  }
+
+  // Step 4: Rate limit check
+  if (!is_mock_mode()) {
+    const rate = consume_llm_call()
+    if (!rate.allowed) {
+      return error({ rate_limit: [{ code: "rate_limit", message: rate.error ?? "rate limit exceeded" }] })
+    }
+  }
+
+  // Step 5: LLM synthesis
+  emit?.("progress", { phase: "synthesizing" })
+
+  let result
+  try {
+    result = await ask_knowledge({
+      question,
+      concepts: all_concepts,
+      edges: all_edges,
+      episodes: episode_matches,
+      lens_prompt,
+    })
+  } catch (e: any) {
+    return error({ llm: [{ code: "synthesis_failed", message: e.message ?? "LLM synthesis failed" }] })
+  }
+
+  return success({
+    answer: result.answer,
+    citations: result.citations,
+    context_loaded: {
+      concepts: all_concepts.length,
+      episodes: episode_matches.length,
+      edges: all_edges.length,
+    },
+  })
+}

--- a/src/handlers/calabi/digest.ts
+++ b/src/handlers/calabi/digest.ts
@@ -10,7 +10,7 @@
 
 import type { Params, Result, Emit } from "../../lib/types.ts"
 import { success, error } from "../../lib/result.ts"
-import { open_state, resolve_lens_paths } from "../../lib/state.ts"
+import { open_state, resolve_lens_paths, get_active_lens_prompts } from "../../lib/state.ts"
 import { load_source } from "../../lib/source-loader.ts"
 import { digest_content } from "../../lib/llm/digest.ts"
 import { auto_tag } from "../../lib/auto-tag.ts"
@@ -122,7 +122,7 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Diges
   const source = p.source.trim()
   const dry_run = p.dry_run === true
   const agent_id = typeof p.agent_id === "string" && p.agent_id.trim() ? p.agent_id.trim() : "cli"
-  const lens_prompt = typeof p.lens === "string" && p.lens.trim() ? p.lens.trim() : undefined
+  const lens_prompt = typeof p.lens === "string" && p.lens.trim() ? p.lens.trim() : get_active_lens_prompts()
 
   // Local code directories delegate to the ingest pipeline
   // (AST parsing, body.db tracking, provenance, change detection)

--- a/src/handlers/calabi/enhance.ts
+++ b/src/handlers/calabi/enhance.ts
@@ -16,6 +16,7 @@ import { consume_llm_call } from "../../lib/rate-limit.ts"
 import { is_mock_mode } from "../../lib/llm/index.ts"
 import { auto_tag } from "../../lib/auto-tag.ts"
 import { sys } from "../../index.ts"
+import { get_active_lens_prompts } from "../../lib/state.ts"
 
 interface EnhanceParams {
   focus?:    string    // topic to focus refinement on
@@ -50,6 +51,7 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Enhan
   const dry_run = p.dry_run === true
   const agent_id = typeof p.agent_id === "string" && p.agent_id.trim() ? p.agent_id.trim() : "cli"
   const focus = typeof p.focus === "string" && p.focus.trim() ? p.focus.trim() : undefined
+  const lens_prompt = get_active_lens_prompts()
 
   const all_rounds: EnhanceRoundResult[] = []
   let total_merges = 0
@@ -133,6 +135,7 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Enhan
         focus,
         round,
         total_rounds: rounds,
+        lens_prompt,
       })
     } catch (e: any) {
       return error({ llm: [{ code: "enhance_failed", message: e.message ?? "LLM refinement failed" }] })

--- a/src/handlers/calabi/enhance.ts
+++ b/src/handlers/calabi/enhance.ts
@@ -1,0 +1,220 @@
+//
+// enhance.ts - convergent refinement of existing knowledge
+//
+// Loads current graph state, asks LLM to identify:
+// - Redundant concepts to merge
+// - Missing edges between existing concepts
+// - Contradictions, gaps, quality observations
+//
+// Does NOT add new topics. Only refines what's there.
+//
+
+import type { Params, Result, Emit } from "../../lib/types.ts"
+import { success, error } from "../../lib/result.ts"
+import { enhance_knowledge } from "../../lib/llm/enhance.ts"
+import { consume_llm_call } from "../../lib/rate-limit.ts"
+import { is_mock_mode } from "../../lib/llm/index.ts"
+import { auto_tag } from "../../lib/auto-tag.ts"
+import { sys } from "../../index.ts"
+
+interface EnhanceParams {
+  focus?:    string    // topic to focus refinement on
+  rounds?:   number    // iterative passes (default 1)
+  limit?:    number    // max context items (default 30)
+  agent_id?: string
+  dry_run?:  boolean
+}
+
+interface EnhanceRoundResult {
+  round:              number
+  merges_applied:     number
+  edges_created:      number
+  observations_added: number
+  reasoning:          string
+}
+
+interface EnhanceResult {
+  rounds_completed:     number
+  total_merges:         number
+  total_edges:          number
+  total_observations:   number
+  rounds:               EnhanceRoundResult[]
+  dry_run:              boolean
+}
+
+export async function handler(params: Params, emit?: Emit): Promise<Result<EnhanceResult>> {
+  const p = (params ?? {}) as EnhanceParams
+
+  const rounds = typeof p.rounds === "number" && p.rounds > 0 ? Math.min(p.rounds, 5) : 1
+  const limit = typeof p.limit === "number" && p.limit > 0 ? p.limit : 30
+  const dry_run = p.dry_run === true
+  const agent_id = typeof p.agent_id === "string" && p.agent_id.trim() ? p.agent_id.trim() : "cli"
+  const focus = typeof p.focus === "string" && p.focus.trim() ? p.focus.trim() : undefined
+
+  const all_rounds: EnhanceRoundResult[] = []
+  let total_merges = 0
+  let total_edges = 0
+  let total_observations = 0
+
+  for (let round = 1; round <= rounds; round++) {
+    emit?.("progress", { phase: "loading_context", round, total_rounds: rounds })
+
+    // Load concepts — focused or broad
+    let concepts: { id: number; name: string; type: string }[] = []
+
+    if (focus) {
+      const search_result = await sys.call("/mind/search", { query: focus, limit })
+      concepts = search_result.status === "success"
+        ? ((search_result.result as any)?.matches ?? []) as { id: number; name: string; type: string }[]
+        : []
+    }
+
+    // Always include a broad sample too
+    const list_result = await sys.call("/mind/concepts/list", { limit })
+    const listed = list_result.status === "success"
+      ? ((list_result.result as any)?.concepts ?? []) as { id: number; name: string; type: string }[]
+      : []
+
+    // Merge, dedup by id
+    const seen_ids = new Set(concepts.map(c => c.id))
+    for (const c of listed) {
+      if (!seen_ids.has(c.id)) {
+        seen_ids.add(c.id)
+        concepts.push(c)
+      }
+    }
+
+    // Nothing to refine
+    if (concepts.length === 0) {
+      return success({
+        rounds_completed: 0,
+        total_merges: 0,
+        total_edges: 0,
+        total_observations: 0,
+        rounds: [],
+        dry_run,
+      })
+    }
+
+    // Load edges
+    const edge_result = await sys.call("/mind/edges/list", { limit })
+    const edges = edge_result.status === "success"
+      ? ((edge_result.result as any)?.edges ?? []).map((e: any) => ({
+          id: e.id,
+          source_name: e.source_name ?? `concept#${e.source}`,
+          target_name: e.target_name ?? `concept#${e.target}`,
+          relation: e.relation,
+        }))
+      : []
+
+    // Load episodes
+    const episode_result = await sys.call("/mind/episodes/list", { limit: Math.ceil(limit / 2) })
+    const episodes = episode_result.status === "success"
+      ? ((episode_result.result as any)?.episodes ?? []) as { id: number; observation: string; context?: string; tags?: string[] }[]
+      : []
+
+    // Rate limit check
+    if (!is_mock_mode()) {
+      const rate = consume_llm_call()
+      if (!rate.allowed) {
+        return error({ rate_limit: [{ code: "rate_limit", message: rate.error ?? "rate limit exceeded" }] })
+      }
+    }
+
+    emit?.("progress", { phase: "analyzing", round, total_rounds: rounds })
+
+    // LLM analysis
+    let enhance_result
+    try {
+      enhance_result = await enhance_knowledge({
+        concepts,
+        edges,
+        episodes,
+        focus,
+        round,
+        total_rounds: rounds,
+      })
+    } catch (e: any) {
+      return error({ llm: [{ code: "enhance_failed", message: e.message ?? "LLM refinement failed" }] })
+    }
+
+    const ops = enhance_result.operations
+    let merges_applied = 0
+    let edges_created = 0
+    let observations_added = 0
+
+    // Apply merges (delete the redundant concept, keep the other)
+    if (!dry_run) {
+      for (const merge of ops.merge_concepts) {
+        const remove = concepts.find(c => c.name === merge.remove_name)
+        if (remove) {
+          const del_result = await sys.call("/mind/concepts/delete", { id: remove.id })
+          if (del_result.status === "success") {
+            merges_applied++
+          }
+        }
+      }
+    } else {
+      merges_applied = ops.merge_concepts.length
+    }
+
+    // Apply new edges
+    if (!dry_run && ops.new_edges.length > 0) {
+      const edge_items: { source: number; target: number; relation: string }[] = []
+      for (const e of ops.new_edges) {
+        const src = concepts.find(c => c.name === e.source_name)
+        const tgt = concepts.find(c => c.name === e.target_name)
+        if (src && tgt) {
+          edge_items.push({ source: src.id, target: tgt.id, relation: e.relation })
+        }
+      }
+      if (edge_items.length > 0) {
+        const batch = await sys.call("/mind/edges/create-many", { items: edge_items })
+        if (batch.status === "success") {
+          edges_created = (batch.result as any)?.items?.length ?? 0
+        }
+      }
+    } else if (dry_run) {
+      edges_created = ops.new_edges.length
+    }
+
+    // Store observations as episodes
+    if (!dry_run) {
+      for (const obs of ops.observations) {
+        const tags = auto_tag(obs.observation, obs.tags ?? [])
+        const ep_result = await sys.call("/mind/episodes/create", {
+          observation: obs.observation,
+          context: obs.context ?? "enhance",
+          tags,
+          agent_id,
+        })
+        if (ep_result.status === "success") {
+          observations_added++
+        }
+      }
+    } else {
+      observations_added = ops.observations.length
+    }
+
+    all_rounds.push({
+      round,
+      merges_applied,
+      edges_created,
+      observations_added,
+      reasoning: enhance_result.reasoning,
+    })
+
+    total_merges += merges_applied
+    total_edges += edges_created
+    total_observations += observations_added
+  }
+
+  return success({
+    rounds_completed: all_rounds.length,
+    total_merges,
+    total_edges,
+    total_observations,
+    rounds: all_rounds,
+    dry_run,
+  })
+}

--- a/src/handlers/calabi/loop.ts
+++ b/src/handlers/calabi/loop.ts
@@ -1,0 +1,311 @@
+//
+// loop.ts - autonomous goal-directed research
+//
+// Cycle: reflect → search → fetch → digest → journal → repeat
+// Stops on convergence or max rounds. State persists for resume.
+//
+
+import type { Params, Result, Emit } from "../../lib/types.ts"
+import { success, error } from "../../lib/result.ts"
+import { reflect_on_goal } from "../../lib/llm/loop.ts"
+import { web_search } from "../../lib/web-search.ts"
+import { consume_llm_call } from "../../lib/rate-limit.ts"
+import { is_mock_mode } from "../../lib/llm/index.ts"
+import { get_active_lens_prompts, open_state } from "../../lib/state.ts"
+import { sys } from "../../index.ts"
+import { randomUUID } from "node:crypto"
+
+interface LoopParams {
+  goal?:      string
+  rounds?:    number     // max rounds (default 5)
+  resume?:    string     // loop ID to resume
+  agent_id?:  string
+  dry_run?:   boolean
+}
+
+interface LoopRound {
+  round:            number
+  assessment:       string
+  gaps:             string[]
+  queries_searched: string[]
+  urls_fetched:     string[]
+  sources_digested: number
+  converging:       boolean
+}
+
+interface LoopState {
+  id:               string
+  goal:             string
+  status:           "running" | "converged" | "paused" | "max_rounds"
+  rounds_completed: number
+  max_rounds:       number
+  search_history:   string[]
+  url_history:      string[]
+  created_at:       string
+  updated_at:       string
+}
+
+interface LoopResult {
+  id:                string
+  goal:              string
+  status:            string
+  rounds_completed:  number
+  rounds:            LoopRound[]
+  dry_run:           boolean
+}
+
+//
+// State persistence in state.db
+//
+
+function ensure_loop_table(db: ReturnType<typeof open_state>): void {
+  if (!db) return
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS loops (
+      id              TEXT PRIMARY KEY,
+      goal            TEXT NOT NULL,
+      status          TEXT NOT NULL DEFAULT 'running',
+      rounds_completed INTEGER NOT NULL DEFAULT 0,
+      max_rounds      INTEGER NOT NULL DEFAULT 5,
+      search_history  TEXT NOT NULL DEFAULT '[]',
+      url_history     TEXT NOT NULL DEFAULT '[]',
+      created_at      TEXT NOT NULL,
+      updated_at      TEXT NOT NULL
+    )
+  `)
+}
+
+function load_loop(db: ReturnType<typeof open_state>, id: string): LoopState | null {
+  if (!db) return null
+  const row = db.query("SELECT * FROM loops WHERE id = ?").get(id) as any
+  if (!row) return null
+  return {
+    ...row,
+    search_history: JSON.parse(row.search_history ?? "[]"),
+    url_history: JSON.parse(row.url_history ?? "[]"),
+  }
+}
+
+function save_loop(db: ReturnType<typeof open_state>, state: LoopState): void {
+  if (!db) return
+  db.run(
+    `INSERT OR REPLACE INTO loops (id, goal, status, rounds_completed, max_rounds, search_history, url_history, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [state.id, state.goal, state.status, state.rounds_completed, state.max_rounds,
+     JSON.stringify(state.search_history), JSON.stringify(state.url_history),
+     state.created_at, state.updated_at],
+  )
+}
+
+function list_loops(db: ReturnType<typeof open_state>): LoopState[] {
+  if (!db) return []
+  const rows = db.query("SELECT * FROM loops ORDER BY updated_at DESC").all() as any[]
+  return rows.map(r => ({
+    ...r,
+    search_history: JSON.parse(r.search_history ?? "[]"),
+    url_history: JSON.parse(r.url_history ?? "[]"),
+  }))
+}
+
+export async function handler(params: Params, emit?: Emit): Promise<Result<any>> {
+  const p = (params ?? {}) as LoopParams & { action?: string }
+
+  // List action
+  if (p.action === "list" || (!p.goal && !p.resume)) {
+    if (!p.goal && !p.resume && p.action !== "list") {
+      // No goal provided and not listing — check if it's truly a list request
+      if (p.action !== "list") {
+        return error({ goal: [{ code: "required", message: "goal is required (or use action: 'list' to list loops)" }] })
+      }
+    }
+    const db = open_state()
+    if (db) {
+      ensure_loop_table(db)
+      const loops = list_loops(db)
+      db.close()
+      return success({ loops })
+    }
+    return success({ loops: [] })
+  }
+
+  const max_rounds = typeof p.rounds === "number" && p.rounds > 0 ? Math.min(p.rounds, 10) : 5
+  const dry_run = p.dry_run === true
+  const agent_id = typeof p.agent_id === "string" && p.agent_id.trim() ? p.agent_id.trim() : "cli"
+  const lens_prompt = get_active_lens_prompts()
+
+  // Load or create loop state
+  const db = open_state()
+  let state: LoopState
+
+  if (p.resume) {
+    if (!db) {
+      return error({ state: [{ code: "not_initialized", message: "state.db not found" }] })
+    }
+    ensure_loop_table(db)
+    const loaded = load_loop(db, p.resume)
+    if (!loaded) {
+      db.close()
+      return error({ resume: [{ code: "not_found", message: `loop "${p.resume}" not found` }] })
+    }
+    state = loaded
+    state.status = "running"
+  } else {
+    const goal = (p.goal as string).trim()
+    if (!goal) {
+      db?.close()
+      return error({ goal: [{ code: "required", message: "goal is required" }] })
+    }
+    state = {
+      id: randomUUID().slice(0, 8),
+      goal,
+      status: "running",
+      rounds_completed: 0,
+      max_rounds,
+      search_history: [],
+      url_history: [],
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    if (db) {
+      ensure_loop_table(db)
+      save_loop(db, state)
+    }
+  }
+
+  const all_rounds: LoopRound[] = []
+  let consecutive_converging = 0
+
+  for (let round = state.rounds_completed + 1; round <= max_rounds; round++) {
+    emit?.("progress", { phase: "reflecting", round, max_rounds, goal: state.goal })
+
+    // Load current knowledge context
+    const search_result = await sys.call("/mind/search", { query: state.goal, limit: 15 })
+    const concepts = search_result.status === "success"
+      ? ((search_result.result as any)?.matches ?? []) as { id: number; name: string; type: string }[]
+      : []
+
+    const ep_result = await sys.call("/mind/episodes/search", { query: state.goal, limit: 10 })
+    const episodes = ep_result.status === "success"
+      ? ((ep_result.result as any)?.matches ?? []) as { id: number; observation: string; context?: string; tags?: string[] }[]
+      : []
+
+    // Rate limit check for reflection LLM call
+    if (!is_mock_mode()) {
+      const rate = consume_llm_call()
+      if (!rate.allowed) {
+        state.status = "paused"
+        state.updated_at = new Date().toISOString()
+        if (db) { save_loop(db, state) }
+        db?.close()
+        return error({ rate_limit: [{ code: "rate_limit", message: rate.error ?? "rate limit exceeded — loop paused" }] })
+      }
+    }
+
+    // Reflect
+    let reflection
+    try {
+      reflection = await reflect_on_goal({
+        goal: state.goal,
+        concepts,
+        episodes,
+        search_history: state.search_history,
+        round,
+        total_rounds: max_rounds,
+        lens_prompt,
+      })
+    } catch (e: any) {
+      state.status = "paused"
+      state.updated_at = new Date().toISOString()
+      if (db) { save_loop(db, state) }
+      db?.close()
+      return error({ llm: [{ code: "reflect_failed", message: e.message ?? "reflection failed" }] })
+    }
+
+    // Track convergence
+    if (reflection.converging) {
+      consecutive_converging++
+    } else {
+      consecutive_converging = 0
+    }
+
+    const round_data: LoopRound = {
+      round,
+      assessment: reflection.assessment,
+      gaps: reflection.gaps,
+      queries_searched: [],
+      urls_fetched: [],
+      sources_digested: 0,
+      converging: reflection.converging,
+    }
+
+    // Search + Fetch + Digest (skip if converging or no queries)
+    if (!dry_run && reflection.queries.length > 0) {
+      emit?.("progress", { phase: "searching", round, queries: reflection.queries.length })
+
+      for (const query of reflection.queries.slice(0, 3)) {
+        state.search_history.push(query)
+        round_data.queries_searched.push(query)
+
+        const sr = await web_search(query)
+        for (const url of sr.urls) {
+          if (state.url_history.includes(url)) continue
+          state.url_history.push(url)
+          round_data.urls_fetched.push(url)
+
+          // Digest the URL
+          emit?.("progress", { phase: "digesting", round, url })
+          const digest_result = await sys.call("/calabi/digest", {
+            source: url,
+            agent_id,
+          })
+          if (digest_result.status === "success") {
+            round_data.sources_digested++
+          }
+        }
+      }
+    } else if (dry_run && reflection.queries.length > 0) {
+      round_data.queries_searched = reflection.queries.slice(0, 3)
+      round_data.urls_fetched = ["(dry-run — not fetched)"]
+    }
+
+    // Journal this round as an episode
+    if (!dry_run) {
+      await sys.call("/mind/episodes/create", {
+        observation: `Loop round ${round}: ${reflection.assessment}`,
+        context: `loop:${state.id}`,
+        tags: ["loop", "research", reflection.converging ? "converging" : "exploring"],
+        agent_id,
+      })
+    }
+
+    all_rounds.push(round_data)
+    state.rounds_completed = round
+    state.updated_at = new Date().toISOString()
+
+    // Save state after each round
+    if (db) { save_loop(db, state) }
+
+    // Check convergence (2 consecutive or no queries)
+    if (consecutive_converging >= 2 || (reflection.queries.length === 0 && reflection.converging)) {
+      state.status = "converged"
+      break
+    }
+  }
+
+  // Final status
+  if (state.status === "running") {
+    state.status = state.rounds_completed >= max_rounds ? "max_rounds" : "running"
+  }
+  state.updated_at = new Date().toISOString()
+  if (db) { save_loop(db, state) }
+  db?.close()
+
+  return success({
+    id: state.id,
+    goal: state.goal,
+    status: state.status,
+    rounds_completed: all_rounds.length,
+    rounds: all_rounds,
+    dry_run,
+  })
+}

--- a/src/handlers/calabi/rebuild.ts
+++ b/src/handlers/calabi/rebuild.ts
@@ -1,0 +1,165 @@
+//
+// rebuild.ts - re-extract all sources through current lenses
+//
+// Lists all previously digested sources, clears their digest records,
+// and re-processes each through the current digest pipeline (with
+// active lens prompts). Sources that are no longer accessible are skipped.
+//
+
+import type { Params, Result, Emit } from "../../lib/types.ts"
+import { success, error } from "../../lib/result.ts"
+import { open_state } from "../../lib/state.ts"
+import { sys } from "../../index.ts"
+
+interface RebuildParams {
+  lens?:     string    // override lens prompt for rebuild
+  agent_id?: string
+  dry_run?:  boolean
+}
+
+interface RebuildSourceResult {
+  label:    string
+  status:   "rebuilt" | "skipped" | "failed"
+  reason?:  string
+}
+
+interface RebuildResult {
+  sources_total:   number
+  sources_rebuilt:  number
+  sources_skipped:  number
+  sources_failed:   number
+  details:          RebuildSourceResult[]
+  dry_run:          boolean
+}
+
+function ensure_digest_table(db: ReturnType<typeof open_state>): void {
+  if (!db) return
+  db.run(`
+    CREATE TABLE IF NOT EXISTS digested_sources (
+      hash         TEXT PRIMARY KEY,
+      label        TEXT NOT NULL,
+      digested_at  TEXT NOT NULL,
+      concepts     INTEGER NOT NULL,
+      edges        INTEGER NOT NULL,
+      episodes     INTEGER NOT NULL
+    )
+  `)
+}
+
+export async function handler(params: Params, emit?: Emit): Promise<Result<RebuildResult>> {
+  const p = (params ?? {}) as RebuildParams
+
+  const dry_run = p.dry_run === true
+  const agent_id = typeof p.agent_id === "string" && p.agent_id.trim() ? p.agent_id.trim() : "cli"
+  const lens = typeof p.lens === "string" && p.lens.trim() ? p.lens.trim() : undefined
+
+  // Open state.db to read digested sources
+  const db = open_state()
+  if (!db) {
+    return error({ state: [{ code: "not_initialized", message: "state.db not found (run brane init)" }] })
+  }
+
+  ensure_digest_table(db)
+
+  // Get all digested sources ordered chronologically
+  const rows = db.query(
+    "SELECT hash, label, digested_at, concepts, edges, episodes FROM digested_sources ORDER BY digested_at ASC"
+  ).all() as { hash: string; label: string; digested_at: string; concepts: number; edges: number; episodes: number }[]
+
+  if (rows.length === 0) {
+    db.close()
+    return success({
+      sources_total: 0,
+      sources_rebuilt: 0,
+      sources_skipped: 0,
+      sources_failed: 0,
+      details: [],
+      dry_run,
+    })
+  }
+
+  if (dry_run) {
+    db.close()
+    const total_concepts = rows.reduce((s, r) => s + r.concepts, 0)
+    const total_edges = rows.reduce((s, r) => s + r.edges, 0)
+    const total_episodes = rows.reduce((s, r) => s + r.episodes, 0)
+
+    emit?.("progress", {
+      phase: "dry_run",
+      sources: rows.length,
+      concepts: total_concepts,
+      edges: total_edges,
+      episodes: total_episodes,
+    })
+
+    return success({
+      sources_total: rows.length,
+      sources_rebuilt: 0,
+      sources_skipped: 0,
+      sources_failed: 0,
+      details: rows.map(r => ({
+        label: r.label,
+        status: "skipped" as const,
+        reason: `would rebuild (${r.concepts}c/${r.edges}e/${r.episodes}ep)`,
+      })),
+      dry_run,
+    })
+  }
+
+  // Clear all digest records so they get re-processed
+  emit?.("progress", { phase: "clearing", sources: rows.length })
+  db.run("DELETE FROM digested_sources")
+  db.close()
+
+  // Re-digest each source chronologically
+  const details: RebuildSourceResult[] = []
+  let rebuilt = 0
+  let skipped = 0
+  let failed = 0
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]
+    emit?.("progress", {
+      phase: "rebuilding",
+      current: i + 1,
+      total: rows.length,
+      label: row.label,
+    })
+
+    // Skip stdin sources (can't re-load)
+    if (row.label === "stdin" || row.label === "-") {
+      details.push({ label: row.label, status: "skipped", reason: "stdin not re-loadable" })
+      skipped++
+      continue
+    }
+
+    // Re-digest through the current pipeline
+    const digest_params: Record<string, unknown> = {
+      source: row.label,
+      agent_id,
+    }
+    if (lens) digest_params.lens = lens
+
+    const result = await sys.call("/calabi/digest", digest_params)
+
+    if (result.status === "success") {
+      details.push({ label: row.label, status: "rebuilt" })
+      rebuilt++
+    } else {
+      const err_msg = result.errors
+        ? JSON.stringify(result.errors).slice(0, 100)
+        : "unknown error"
+      details.push({ label: row.label, status: "failed", reason: err_msg })
+      failed++
+    }
+  }
+
+  return success({
+    sources_total: rows.length,
+    sources_rebuilt: rebuilt,
+    sources_skipped: skipped,
+    sources_failed: failed,
+    details,
+    dry_run,
+  })
+}

--- a/src/handlers/calabi/storm.ts
+++ b/src/handlers/calabi/storm.ts
@@ -13,6 +13,7 @@ import { consume_llm_call } from "../../lib/rate-limit.ts"
 import { is_mock_mode } from "../../lib/llm/index.ts"
 import { auto_tag } from "../../lib/auto-tag.ts"
 import { sys } from "../../index.ts"
+import { get_active_lens_prompts } from "../../lib/state.ts"
 import { readFileSync, existsSync } from "node:fs"
 import { resolve } from "node:path"
 
@@ -52,6 +53,7 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Storm
   const dry_run = p.dry_run === true
   const agent_id = typeof p.agent_id === "string" && p.agent_id.trim() ? p.agent_id.trim() : "cli"
   const seed = typeof p.seed === "string" && p.seed.trim() ? p.seed.trim() : undefined
+  const lens_prompt = get_active_lens_prompts()
 
   // Load input file if provided
   let input_content: string | undefined
@@ -142,6 +144,7 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Storm
         episodes,
         round,
         total_rounds: rounds,
+        lens_prompt,
       })
     } catch (e: any) {
       return error({ llm: [{ code: "storm_failed", message: e.message ?? "LLM brainstorming failed" }] })

--- a/src/handlers/calabi/storm.ts
+++ b/src/handlers/calabi/storm.ts
@@ -1,0 +1,241 @@
+//
+// storm.ts - divergent brainstorming over accumulated knowledge
+//
+// Loads context (vector search or broad sample), generates new
+// concepts/edges/episodes + suggestions via LLM. Supports multi-round
+// deepening where each round sees previous round's additions.
+//
+
+import type { Params, Result, Emit } from "../../lib/types.ts"
+import { success, error } from "../../lib/result.ts"
+import { storm_knowledge } from "../../lib/llm/storm.ts"
+import { consume_llm_call } from "../../lib/rate-limit.ts"
+import { is_mock_mode } from "../../lib/llm/index.ts"
+import { auto_tag } from "../../lib/auto-tag.ts"
+import { sys } from "../../index.ts"
+import { readFileSync, existsSync } from "node:fs"
+import { resolve } from "node:path"
+
+interface StormParams {
+  seed?:     string    // topic to brainstorm about
+  input?:    string    // file path to brainstorm against
+  rounds?:   number    // iterative rounds (default 1)
+  limit?:    number    // max context items per round (default 20)
+  agent_id?: string
+  dry_run?:  boolean
+}
+
+interface StormRoundResult {
+  round:              number
+  concepts_created:   number
+  edges_created:      number
+  episodes_created:   number
+  suggestions:        { kind: string; value: string; reason: string }[]
+  reasoning:          string
+}
+
+interface StormResult {
+  rounds_completed:   number
+  total_concepts:     number
+  total_edges:        number
+  total_episodes:     number
+  suggestions:        { kind: string; value: string; reason: string }[]
+  rounds:             StormRoundResult[]
+  dry_run:            boolean
+}
+
+export async function handler(params: Params, emit?: Emit): Promise<Result<StormResult>> {
+  const p = (params ?? {}) as StormParams
+
+  const rounds = typeof p.rounds === "number" && p.rounds > 0 ? Math.min(p.rounds, 5) : 1
+  const limit = typeof p.limit === "number" && p.limit > 0 ? p.limit : 20
+  const dry_run = p.dry_run === true
+  const agent_id = typeof p.agent_id === "string" && p.agent_id.trim() ? p.agent_id.trim() : "cli"
+  const seed = typeof p.seed === "string" && p.seed.trim() ? p.seed.trim() : undefined
+
+  // Load input file if provided
+  let input_content: string | undefined
+  if (typeof p.input === "string" && p.input.trim()) {
+    const input_path = resolve(p.input.trim())
+    if (!existsSync(input_path)) {
+      return error({ input: [{ code: "not_found", message: `File not found: ${p.input}` }] })
+    }
+    try {
+      input_content = readFileSync(input_path, "utf-8")
+      if (input_content.length > 100_000) {
+        input_content = input_content.slice(0, 100_000) + "\n\n[... truncated at 100KB ...]"
+      }
+    } catch (e: any) {
+      return error({ input: [{ code: "read_failed", message: e.message ?? "Failed to read input file" }] })
+    }
+  }
+
+  const all_rounds: StormRoundResult[] = []
+  let total_concepts = 0
+  let total_edges = 0
+  let total_episodes = 0
+  let all_suggestions: { kind: string; value: string; reason: string }[] = []
+
+  for (let round = 1; round <= rounds; round++) {
+    emit?.("progress", { phase: "loading_context", round, total_rounds: rounds })
+
+    // Load context — seeded search or broad sample
+    const query = seed ?? "knowledge graph overview"
+    const half = Math.ceil(limit / 2)
+
+    const concept_result = await sys.call("/mind/concepts/list", { limit: half })
+    const concepts = concept_result.status === "success"
+      ? ((concept_result.result as any)?.items ?? []) as { id: number; name: string; type: string }[]
+      : []
+
+    // Also vector search if we have a seed
+    if (seed) {
+      const search_result = await sys.call("/mind/search", { query: seed, limit: half })
+      const matches = search_result.status === "success"
+        ? ((search_result.result as any)?.matches ?? []) as { id: number; name: string; type: string }[]
+        : []
+      // Merge, dedup by id
+      const seen = new Set(concepts.map(c => c.id))
+      for (const m of matches) {
+        if (!seen.has(m.id)) {
+          seen.add(m.id)
+          concepts.push(m)
+        }
+      }
+    }
+
+    // Load edges for context
+    const edge_result = await sys.call("/mind/edges/list", { limit: half })
+    const edges = edge_result.status === "success"
+      ? ((edge_result.result as any)?.items ?? []).map((e: any) => ({
+          id: e.id,
+          source_name: e.source_name ?? `concept#${e.source}`,
+          target_name: e.target_name ?? `concept#${e.target}`,
+          relation: e.relation,
+        }))
+      : []
+
+    // Load episodes
+    const episode_result = await sys.call("/mind/episodes/list", { limit: half })
+    const episodes = episode_result.status === "success"
+      ? ((episode_result.result as any)?.items ?? []) as { id: number; observation: string; context?: string; tags?: string[] }[]
+      : []
+
+    // Rate limit check
+    if (!is_mock_mode()) {
+      const rate = consume_llm_call()
+      if (!rate.allowed) {
+        return error({ rate_limit: [{ code: "rate_limit", message: rate.error ?? "rate limit exceeded" }] })
+      }
+    }
+
+    emit?.("progress", { phase: "brainstorming", round, total_rounds: rounds })
+
+    // LLM brainstorm
+    let storm_result
+    try {
+      storm_result = await storm_knowledge({
+        seed,
+        input: input_content,
+        concepts,
+        edges,
+        episodes,
+        round,
+        total_rounds: rounds,
+      })
+    } catch (e: any) {
+      return error({ llm: [{ code: "storm_failed", message: e.message ?? "LLM brainstorming failed" }] })
+    }
+
+    // Write results to graph (unless dry run)
+    let concepts_created = 0
+    let edges_created = 0
+    let episodes_created = 0
+
+    if (!dry_run && storm_result.concepts.length > 0) {
+      const batch = await sys.call("/mind/concepts/create-many", {
+        items: storm_result.concepts.map(c => ({
+          name: c.name,
+          type: c.type,
+          agent_id,
+        })),
+      })
+      if (batch.status === "success") {
+        concepts_created = (batch.result as any)?.items?.length ?? 0
+      }
+    }
+
+    if (!dry_run && storm_result.edges.length > 0) {
+      // Resolve edge names to IDs — look up concepts by name
+      const edge_items: { source: number; target: number; relation: string }[] = []
+      for (const e of storm_result.edges) {
+        const src = await resolve_concept_id(e.source_name)
+        const tgt = await resolve_concept_id(e.target_name)
+        if (src && tgt) {
+          edge_items.push({ source: src, target: tgt, relation: e.relation })
+        }
+      }
+
+      if (edge_items.length > 0) {
+        const batch = await sys.call("/mind/edges/create-many", { items: edge_items })
+        if (batch.status === "success") {
+          edges_created = (batch.result as any)?.items?.length ?? 0
+        }
+      }
+    }
+
+    if (!dry_run && storm_result.episodes.length > 0) {
+      for (const ep of storm_result.episodes) {
+        const tags = auto_tag(ep.observation, ep.tags ?? [])
+        const ep_result = await sys.call("/mind/episodes/create", {
+          observation: ep.observation,
+          context: ep.context ?? "storm",
+          tags,
+          agent_id,
+        })
+        if (ep_result.status === "success") {
+          episodes_created++
+        }
+      }
+    }
+
+    const round_result: StormRoundResult = {
+      round,
+      concepts_created: dry_run ? storm_result.concepts.length : concepts_created,
+      edges_created: dry_run ? storm_result.edges.length : edges_created,
+      episodes_created: dry_run ? storm_result.episodes.length : episodes_created,
+      suggestions: storm_result.suggestions,
+      reasoning: storm_result.reasoning,
+    }
+
+    all_rounds.push(round_result)
+    total_concepts += round_result.concepts_created
+    total_edges += round_result.edges_created
+    total_episodes += round_result.episodes_created
+    all_suggestions = [...all_suggestions, ...storm_result.suggestions]
+
+    // Clear input for subsequent rounds (only use on first round)
+    input_content = undefined
+  }
+
+  return success({
+    rounds_completed: all_rounds.length,
+    total_concepts,
+    total_edges,
+    total_episodes,
+    suggestions: all_suggestions,
+    rounds: all_rounds,
+    dry_run,
+  })
+}
+
+//
+// Resolve a concept name to its ID
+//
+async function resolve_concept_id(name: string): Promise<number | null> {
+  const result = await sys.call("/mind/concepts/list", { limit: 200 })
+  if (result.status !== "success") return null
+  const items = (result.result as any)?.items ?? []
+  const match = items.find((c: any) => c.name === name)
+  return match?.id ?? null
+}

--- a/src/handlers/calabi/storm.ts
+++ b/src/handlers/calabi/storm.ts
@@ -85,7 +85,7 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Storm
 
     const concept_result = await sys.call("/mind/concepts/list", { limit: half })
     const concepts = concept_result.status === "success"
-      ? ((concept_result.result as any)?.items ?? []) as { id: number; name: string; type: string }[]
+      ? ((concept_result.result as any)?.concepts ?? []) as { id: number; name: string; type: string }[]
       : []
 
     // Also vector search if we have a seed
@@ -107,7 +107,7 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Storm
     // Load edges for context
     const edge_result = await sys.call("/mind/edges/list", { limit: half })
     const edges = edge_result.status === "success"
-      ? ((edge_result.result as any)?.items ?? []).map((e: any) => ({
+      ? ((edge_result.result as any)?.edges ?? []).map((e: any) => ({
           id: e.id,
           source_name: e.source_name ?? `concept#${e.source}`,
           target_name: e.target_name ?? `concept#${e.target}`,
@@ -118,7 +118,7 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Storm
     // Load episodes
     const episode_result = await sys.call("/mind/episodes/list", { limit: half })
     const episodes = episode_result.status === "success"
-      ? ((episode_result.result as any)?.items ?? []) as { id: number; observation: string; context?: string; tags?: string[] }[]
+      ? ((episode_result.result as any)?.episodes ?? []) as { id: number; observation: string; context?: string; tags?: string[] }[]
       : []
 
     // Rate limit check
@@ -235,7 +235,7 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Storm
 async function resolve_concept_id(name: string): Promise<number | null> {
   const result = await sys.call("/mind/concepts/list", { limit: 200 })
   if (result.status !== "success") return null
-  const items = (result.result as any)?.items ?? []
+  const items = (result.result as any)?.concepts ?? []
   const match = items.find((c: any) => c.name === name)
   return match?.id ?? null
 }

--- a/src/handlers/calabi/tldr.ts
+++ b/src/handlers/calabi/tldr.ts
@@ -1,0 +1,130 @@
+//
+// tldr.ts - knowledge outline with synopses
+//
+// Loads the full graph (concepts, edges, episodes), sends to LLM
+// for topical organization. Appends stats footer.
+//
+
+import type { Params, Result, Emit } from "../../lib/types.ts"
+import { success, error } from "../../lib/result.ts"
+import { tldr_knowledge } from "../../lib/llm/tldr.ts"
+import { consume_llm_call } from "../../lib/rate-limit.ts"
+import { is_mock_mode } from "../../lib/llm/index.ts"
+import { get_active_lens_prompts } from "../../lib/state.ts"
+import { sys } from "../../index.ts"
+
+interface TldrParams {
+  focus?:    string    // narrow to a topic
+  limit?:    number    // max items to load (default 50)
+  agent_id?: string
+}
+
+interface TldrTopic {
+  title: string
+  items: string[]
+}
+
+interface TldrResult {
+  topics:      TldrTopic[]
+  learnings:   string[]
+  stats: {
+    concepts:  number
+    edges:     number
+    episodes:  number
+    topics:    number
+  }
+}
+
+export async function handler(params: Params, emit?: Emit): Promise<Result<TldrResult>> {
+  const p = (params ?? {}) as TldrParams
+
+  const limit = typeof p.limit === "number" && p.limit > 0 ? p.limit : 50
+  const focus = typeof p.focus === "string" && p.focus.trim() ? p.focus.trim() : undefined
+  const lens_prompt = get_active_lens_prompts()
+
+  emit?.("progress", { phase: "loading" })
+
+  // Load concepts
+  let concepts: { id: number; name: string; type: string }[] = []
+
+  if (focus) {
+    const search_result = await sys.call("/mind/search", { query: focus, limit })
+    concepts = search_result.status === "success"
+      ? ((search_result.result as any)?.matches ?? []) as { id: number; name: string; type: string }[]
+      : []
+  }
+
+  // Broad listing too
+  const list_result = await sys.call("/mind/concepts/list", { limit })
+  const listed = list_result.status === "success"
+    ? ((list_result.result as any)?.concepts ?? []) as { id: number; name: string; type: string }[]
+    : []
+
+  const seen_ids = new Set(concepts.map(c => c.id))
+  for (const c of listed) {
+    if (!seen_ids.has(c.id)) {
+      seen_ids.add(c.id)
+      concepts.push(c)
+    }
+  }
+
+  // Load edges
+  const edge_result = await sys.call("/mind/edges/list", { limit })
+  const edges = edge_result.status === "success"
+    ? ((edge_result.result as any)?.edges ?? []).map((e: any) => ({
+        id: e.id,
+        source_name: e.source_name ?? `concept#${e.source}`,
+        target_name: e.target_name ?? `concept#${e.target}`,
+        relation: e.relation,
+      }))
+    : []
+
+  // Load episodes
+  const episode_result = await sys.call("/mind/episodes/list", { limit: Math.ceil(limit / 2) })
+  const episodes = episode_result.status === "success"
+    ? ((episode_result.result as any)?.episodes ?? []) as { id: number; observation: string; context?: string; tags?: string[]; timestamp?: string }[]
+    : []
+
+  // Empty graph
+  if (concepts.length === 0 && episodes.length === 0) {
+    return success({
+      topics: [],
+      learnings: [],
+      stats: { concepts: 0, edges: 0, episodes: 0, topics: 0 },
+    })
+  }
+
+  // Rate limit
+  if (!is_mock_mode()) {
+    const rate = consume_llm_call()
+    if (!rate.allowed) {
+      return error({ rate_limit: [{ code: "rate_limit", message: rate.error ?? "rate limit exceeded" }] })
+    }
+  }
+
+  emit?.("progress", { phase: "organizing" })
+
+  let result
+  try {
+    result = await tldr_knowledge({
+      concepts,
+      edges,
+      episodes,
+      focus,
+      lens_prompt,
+    })
+  } catch (e: any) {
+    return error({ llm: [{ code: "tldr_failed", message: e.message ?? "LLM outline failed" }] })
+  }
+
+  return success({
+    topics: result.topics,
+    learnings: result.learnings,
+    stats: {
+      concepts: concepts.length,
+      edges: edges.length,
+      episodes: episodes.length,
+      topics: result.topics.length,
+    },
+  })
+}

--- a/src/handlers/lens/prompt.ts
+++ b/src/handlers/lens/prompt.ts
@@ -1,0 +1,127 @@
+//
+// prompt.ts - manage lens prompts (create, activate, deactivate, list)
+//
+// Lens prompts are cognitive filters stored in state.db that shape
+// how digest, storm, enhance, and ask process information.
+//
+
+import type { Params, Result, Emit } from "../../lib/types.ts"
+import { success, error } from "../../lib/result.ts"
+import {
+  set_lens_prompt,
+  get_lens_prompt,
+  delete_lens_prompt,
+  activate_lens_prompt,
+  deactivate_lens_prompt,
+  list_lens_prompts,
+} from "../../lib/state.ts"
+
+interface PromptSetParams {
+  action:      "set"
+  name:        string
+  prompt:      string
+  description?: string
+}
+
+interface PromptActivateParams {
+  action:  "on" | "off"
+  name:    string
+}
+
+interface PromptDeleteParams {
+  action:  "delete"
+  name:    string
+}
+
+interface PromptListParams {
+  action:  "list"
+}
+
+interface PromptGetParams {
+  action:  "get"
+  name:    string
+}
+
+type PromptParams = PromptSetParams | PromptActivateParams | PromptDeleteParams | PromptListParams | PromptGetParams
+
+export async function handler(params: Params, emit?: Emit): Promise<Result<any>> {
+  const p = (params ?? {}) as PromptParams
+
+  if (!p.action || typeof p.action !== "string") {
+    return error({ action: [{ code: "required", message: "action is required (set, on, off, delete, list, get)" }] })
+  }
+
+  switch (p.action) {
+    case "set": {
+      const sp = p as PromptSetParams
+      if (!sp.name || typeof sp.name !== "string" || !sp.name.trim()) {
+        return error({ name: [{ code: "required", message: "name is required" }] })
+      }
+      if (!sp.prompt || typeof sp.prompt !== "string" || !sp.prompt.trim()) {
+        return error({ prompt: [{ code: "required", message: "prompt is required" }] })
+      }
+      const ok = set_lens_prompt(sp.name.trim(), sp.prompt.trim(), sp.description?.trim())
+      if (!ok) {
+        return error({ state: [{ code: "write_failed", message: "failed to save lens prompt (is brane initialized?)" }] })
+      }
+      const info = get_lens_prompt(sp.name.trim())
+      return success(info)
+    }
+
+    case "on": {
+      const ap = p as PromptActivateParams
+      if (!ap.name || typeof ap.name !== "string" || !ap.name.trim()) {
+        return error({ name: [{ code: "required", message: "name is required" }] })
+      }
+      const ok = activate_lens_prompt(ap.name.trim())
+      if (!ok) {
+        return error({ name: [{ code: "not_found", message: `lens prompt "${ap.name}" not found` }] })
+      }
+      return success({ name: ap.name.trim(), active: true })
+    }
+
+    case "off": {
+      const dp = p as PromptActivateParams
+      if (!dp.name || typeof dp.name !== "string" || !dp.name.trim()) {
+        return error({ name: [{ code: "required", message: "name is required" }] })
+      }
+      const ok = deactivate_lens_prompt(dp.name.trim())
+      if (!ok) {
+        return error({ state: [{ code: "write_failed", message: "failed to deactivate lens prompt" }] })
+      }
+      return success({ name: dp.name.trim(), active: false })
+    }
+
+    case "delete": {
+      const ddp = p as PromptDeleteParams
+      if (!ddp.name || typeof ddp.name !== "string" || !ddp.name.trim()) {
+        return error({ name: [{ code: "required", message: "name is required" }] })
+      }
+      const ok = delete_lens_prompt(ddp.name.trim())
+      if (!ok) {
+        return error({ state: [{ code: "write_failed", message: "failed to delete lens prompt" }] })
+      }
+      return success({ name: ddp.name.trim(), deleted: true })
+    }
+
+    case "get": {
+      const gp = p as PromptGetParams
+      if (!gp.name || typeof gp.name !== "string" || !gp.name.trim()) {
+        return error({ name: [{ code: "required", message: "name is required" }] })
+      }
+      const info = get_lens_prompt(gp.name.trim())
+      if (!info) {
+        return error({ name: [{ code: "not_found", message: `lens prompt "${gp.name}" not found` }] })
+      }
+      return success(info)
+    }
+
+    case "list": {
+      const prompts = list_lens_prompts()
+      return success({ prompts })
+    }
+
+    default:
+      return error({ action: [{ code: "invalid", message: `unknown action "${p.action}" (expected: set, on, off, delete, list, get)` }] })
+  }
+}

--- a/src/handlers/state/init.ts
+++ b/src/handlers/state/init.ts
@@ -39,6 +39,16 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<InitR
           value TEXT NOT NULL
         )
       `)
+      // Ensure lens_prompts table exists (idempotent)
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lens_prompts (
+          name        TEXT PRIMARY KEY,
+          prompt      TEXT NOT NULL,
+          description TEXT NOT NULL DEFAULT '',
+          active      INTEGER NOT NULL DEFAULT 0,
+          created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `)
       // Do NOT reset active_lens if already set (init idempotency)
       const row = db.query("SELECT value FROM config WHERE key = ?").get("active_lens")
       if (!row) {
@@ -69,6 +79,15 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<InitR
       CREATE TABLE IF NOT EXISTS config (
         key   TEXT PRIMARY KEY,
         value TEXT NOT NULL
+      )
+    `)
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS lens_prompts (
+        name        TEXT PRIMARY KEY,
+        prompt      TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        active      INTEGER NOT NULL DEFAULT 0,
+        created_at  TEXT NOT NULL DEFAULT (datetime('now'))
       )
     `)
     db.run("INSERT INTO config (key, value) VALUES (?, ?)", ["active_lens", "default"])

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ import { handler as calabi_storm_handler } from "./handlers/calabi/storm.ts"
 import { handler as calabi_enhance_handler } from "./handlers/calabi/enhance.ts"
 import { handler as lens_prompt_handler } from "./handlers/lens/prompt.ts"
 import { handler as calabi_loop_handler } from "./handlers/calabi/loop.ts"
+import { handler as calabi_rebuild_handler } from "./handlers/calabi/rebuild.ts"
 
 sys.register("/ping", ping_handler)
 sys.register("/body/init", body_init_handler)
@@ -152,6 +153,7 @@ sys.register("/calabi/storm", calabi_storm_handler)
 sys.register("/calabi/enhance", calabi_enhance_handler)
 sys.register("/lens/prompt", lens_prompt_handler)
 sys.register("/calabi/loop", calabi_loop_handler)
+sys.register("/calabi/rebuild", calabi_rebuild_handler)
 
 // export
 export { sys }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ import { handler as calabi_ask_handler } from "./handlers/calabi/ask.ts"
 import { handler as calabi_storm_handler } from "./handlers/calabi/storm.ts"
 import { handler as calabi_enhance_handler } from "./handlers/calabi/enhance.ts"
 import { handler as lens_prompt_handler } from "./handlers/lens/prompt.ts"
+import { handler as calabi_loop_handler } from "./handlers/calabi/loop.ts"
 
 sys.register("/ping", ping_handler)
 sys.register("/body/init", body_init_handler)
@@ -150,6 +151,7 @@ sys.register("/calabi/ask", calabi_ask_handler)
 sys.register("/calabi/storm", calabi_storm_handler)
 sys.register("/calabi/enhance", calabi_enhance_handler)
 sys.register("/lens/prompt", lens_prompt_handler)
+sys.register("/calabi/loop", calabi_loop_handler)
 
 // export
 export { sys }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ import { handler as calabi_enhance_handler } from "./handlers/calabi/enhance.ts"
 import { handler as lens_prompt_handler } from "./handlers/lens/prompt.ts"
 import { handler as calabi_loop_handler } from "./handlers/calabi/loop.ts"
 import { handler as calabi_rebuild_handler } from "./handlers/calabi/rebuild.ts"
+import { handler as calabi_tldr_handler } from "./handlers/calabi/tldr.ts"
 
 sys.register("/ping", ping_handler)
 sys.register("/body/init", body_init_handler)
@@ -154,6 +155,7 @@ sys.register("/calabi/enhance", calabi_enhance_handler)
 sys.register("/lens/prompt", lens_prompt_handler)
 sys.register("/calabi/loop", calabi_loop_handler)
 sys.register("/calabi/rebuild", calabi_rebuild_handler)
+sys.register("/calabi/tldr", calabi_tldr_handler)
 
 // export
 export { sys }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ import { handler as calabi_ingest_sessions_handler } from "./handlers/calabi/ing
 import { handler as calabi_digest_handler } from "./handlers/calabi/digest.ts"
 import { handler as calabi_ask_handler } from "./handlers/calabi/ask.ts"
 import { handler as calabi_storm_handler } from "./handlers/calabi/storm.ts"
+import { handler as calabi_enhance_handler } from "./handlers/calabi/enhance.ts"
 
 sys.register("/ping", ping_handler)
 sys.register("/body/init", body_init_handler)
@@ -146,6 +147,7 @@ sys.register("/calabi/ingest-sessions", calabi_ingest_sessions_handler)
 sys.register("/calabi/digest", calabi_digest_handler)
 sys.register("/calabi/ask", calabi_ask_handler)
 sys.register("/calabi/storm", calabi_storm_handler)
+sys.register("/calabi/enhance", calabi_enhance_handler)
 
 // export
 export { sys }

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ import { handler as mind_agent_lens_init_handler } from "./handlers/mind/agent-l
 import { handler as calabi_ingest_sessions_handler } from "./handlers/calabi/ingest-sessions.ts"
 import { handler as calabi_digest_handler } from "./handlers/calabi/digest.ts"
 import { handler as calabi_ask_handler } from "./handlers/calabi/ask.ts"
+import { handler as calabi_storm_handler } from "./handlers/calabi/storm.ts"
 
 sys.register("/ping", ping_handler)
 sys.register("/body/init", body_init_handler)
@@ -144,6 +145,7 @@ sys.register("/mind/agent-lens/init", mind_agent_lens_init_handler)
 sys.register("/calabi/ingest-sessions", calabi_ingest_sessions_handler)
 sys.register("/calabi/digest", calabi_digest_handler)
 sys.register("/calabi/ask", calabi_ask_handler)
+sys.register("/calabi/storm", calabi_storm_handler)
 
 // export
 export { sys }

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ import { handler as mind_episodes_delete_handler } from "./handlers/mind/episode
 import { handler as mind_agent_lens_init_handler } from "./handlers/mind/agent-lens/init.ts"
 import { handler as calabi_ingest_sessions_handler } from "./handlers/calabi/ingest-sessions.ts"
 import { handler as calabi_digest_handler } from "./handlers/calabi/digest.ts"
+import { handler as calabi_ask_handler } from "./handlers/calabi/ask.ts"
 
 sys.register("/ping", ping_handler)
 sys.register("/body/init", body_init_handler)
@@ -142,6 +143,7 @@ sys.register("/mind/episodes/delete", mind_episodes_delete_handler)
 sys.register("/mind/agent-lens/init", mind_agent_lens_init_handler)
 sys.register("/calabi/ingest-sessions", calabi_ingest_sessions_handler)
 sys.register("/calabi/digest", calabi_digest_handler)
+sys.register("/calabi/ask", calabi_ask_handler)
 
 // export
 export { sys }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ import { handler as calabi_digest_handler } from "./handlers/calabi/digest.ts"
 import { handler as calabi_ask_handler } from "./handlers/calabi/ask.ts"
 import { handler as calabi_storm_handler } from "./handlers/calabi/storm.ts"
 import { handler as calabi_enhance_handler } from "./handlers/calabi/enhance.ts"
+import { handler as lens_prompt_handler } from "./handlers/lens/prompt.ts"
 
 sys.register("/ping", ping_handler)
 sys.register("/body/init", body_init_handler)
@@ -148,6 +149,7 @@ sys.register("/calabi/digest", calabi_digest_handler)
 sys.register("/calabi/ask", calabi_ask_handler)
 sys.register("/calabi/storm", calabi_storm_handler)
 sys.register("/calabi/enhance", calabi_enhance_handler)
+sys.register("/lens/prompt", lens_prompt_handler)
 
 // export
 export { sys }

--- a/src/lib/llm/ask.ts
+++ b/src/lib/llm/ask.ts
@@ -1,0 +1,214 @@
+//
+// ask.ts - LLM-powered question answering over accumulated knowledge
+//
+// Takes a question + retrieved context (concepts, edges, episodes),
+// synthesizes an answer with citations back to specific graph items.
+//
+
+import { spawn } from "node:child_process"
+import { is_mock_mode } from "./index.ts"
+
+export interface AskRequest {
+  question:    string
+  concepts:    { id: number; name: string; type: string; score?: number }[]
+  edges:       { id: number; source_name: string; target_name: string; relation: string }[]
+  episodes:    { id: number; observation: string; context?: string; tags?: string[]; score?: number }[]
+  lens_prompt?: string
+}
+
+export interface AskResult {
+  answer:   string
+  citations: {
+    concept_ids:  number[]
+    episode_ids:  number[]
+    edge_ids:     number[]
+  }
+  reasoning: string
+}
+
+const ASK_SCHEMA = JSON.stringify({
+  type: "object",
+  properties: {
+    answer:    { type: "string", description: "Synthesized answer to the question" },
+    citations: {
+      type: "object",
+      properties: {
+        concept_ids: { type: "array", items: { type: "number" }, description: "IDs of concepts that informed the answer" },
+        episode_ids: { type: "array", items: { type: "number" }, description: "IDs of episodes that informed the answer" },
+        edge_ids:    { type: "array", items: { type: "number" }, description: "IDs of edges that informed the answer" },
+      },
+      required: ["concept_ids", "episode_ids", "edge_ids"],
+    },
+    reasoning: { type: "string", description: "Brief explanation of how the answer was derived" },
+  },
+  required: ["answer", "citations", "reasoning"],
+})
+
+const AGENT_NESTING_VARS = ["CLAUDECODE", "CLAUDE_CODE", "GEMINI_SESSION"]
+
+function clean_env(): Record<string, string | undefined> {
+  const env = { ...process.env }
+  for (const key of AGENT_NESTING_VARS) {
+    delete env[key]
+  }
+  return env
+}
+
+function run_cli(args: string[], stdin: string): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(args[0], args.slice(1), {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: clean_env()
+    })
+
+    let stdout = ""
+    let stderr = ""
+
+    proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString() })
+    proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString() })
+
+    proc.on("error", (err: Error) => reject(err))
+    proc.on("close", (code: number | null) => resolve({ stdout, stderr, code: code ?? 1 }))
+
+    proc.stdin.write(stdin)
+    proc.stdin.end()
+  })
+}
+
+function build_system_prompt(lens_prompt?: string): string {
+  let prompt = `You are a knowledge synthesis system for Brane, an agent memory layer. You answer questions using ONLY the context provided below — do not use outside knowledge.
+
+## Rules
+1. Answer based strictly on the provided concepts, edges, and episodes
+2. If the context doesn't contain enough information, say so explicitly
+3. Cite specific items by their IDs in the citations field
+4. Be concise and direct — synthesize, don't just list
+5. Connect related pieces of information to form a coherent answer
+6. When episodes contradict each other, note the contradiction`
+
+  if (lens_prompt) {
+    prompt += `\n\n## Active Lens\n${lens_prompt}`
+  }
+
+  prompt += `\n\nReturn your answer as structured JSON.`
+  return prompt
+}
+
+function build_user_prompt(request: AskRequest): string {
+  const parts: string[] = [`Question: ${request.question}\n`]
+
+  if (request.concepts.length > 0) {
+    parts.push("## Concepts")
+    for (const c of request.concepts) {
+      const score = c.score != null ? ` (relevance: ${c.score.toFixed(3)})` : ""
+      parts.push(`- [#${c.id}] ${c.name} (${c.type})${score}`)
+    }
+    parts.push("")
+  }
+
+  if (request.edges.length > 0) {
+    parts.push("## Relationships")
+    for (const e of request.edges) {
+      parts.push(`- [edge #${e.id}] ${e.source_name} → ${e.target_name} (${e.relation})`)
+    }
+    parts.push("")
+  }
+
+  if (request.episodes.length > 0) {
+    parts.push("## Memories (Episodes)")
+    for (const ep of request.episodes) {
+      const tags = ep.tags?.length ? ` [${ep.tags.join(", ")}]` : ""
+      const ctx = ep.context ? ` — context: ${ep.context}` : ""
+      parts.push(`- [#${ep.id}] ${ep.observation}${ctx}${tags}`)
+    }
+    parts.push("")
+  }
+
+  if (request.concepts.length === 0 && request.episodes.length === 0) {
+    parts.push("(No relevant context found in the knowledge graph)")
+  }
+
+  return parts.join("\n")
+}
+
+//
+// Mock implementation
+//
+function mock_ask(request: AskRequest): AskResult {
+  const concept_ids = request.concepts.map(c => c.id)
+  const episode_ids = request.episodes.map(e => e.id)
+  const edge_ids = request.edges.map(e => e.id)
+
+  const parts: string[] = []
+  if (request.concepts.length > 0) {
+    parts.push(`Based on ${request.concepts.length} concepts`)
+  }
+  if (request.episodes.length > 0) {
+    parts.push(`${request.episodes.length} memories`)
+  }
+  const answer = parts.length > 0
+    ? `${parts.join(" and ")}: ${request.concepts[0]?.name ?? "unknown"} is relevant to "${request.question}".`
+    : `No relevant context found for: "${request.question}".`
+
+  return {
+    answer,
+    citations: { concept_ids, episode_ids, edge_ids },
+    reasoning: "Mock synthesis",
+  }
+}
+
+//
+// Real implementation
+//
+async function cli_ask(request: AskRequest): Promise<AskResult> {
+  const cli = process.env.BRANE_LLM_CLI ?? "claude"
+  const system_prompt = build_system_prompt(request.lens_prompt)
+  const user_prompt = build_user_prompt(request)
+
+  const args = [
+    cli,
+    "-p",
+    "--output-format", "json",
+    "--system-prompt", system_prompt,
+    "--json-schema", ASK_SCHEMA,
+    "--no-session-persistence",
+  ]
+
+  const result = await run_cli(args, user_prompt)
+
+  if (result.code !== 0) {
+    throw new Error(`${cli} exited with code ${result.code}: ${result.stderr || result.stdout}`)
+  }
+
+  let envelope: any
+  try {
+    envelope = JSON.parse(result.stdout)
+  } catch {
+    throw new Error(`${cli} returned invalid JSON: ${result.stdout.slice(0, 200)}`)
+  }
+
+  const output = envelope.structured_output ?? envelope.result ?? envelope
+  if (!output || typeof output !== "object") {
+    throw new Error(`${cli} returned no structured output`)
+  }
+
+  return {
+    answer: String(output.answer ?? ""),
+    citations: {
+      concept_ids: Array.isArray(output.citations?.concept_ids) ? output.citations.concept_ids : [],
+      episode_ids: Array.isArray(output.citations?.episode_ids) ? output.citations.episode_ids : [],
+      edge_ids: Array.isArray(output.citations?.edge_ids) ? output.citations.edge_ids : [],
+    },
+    reasoning: String(output.reasoning ?? ""),
+  }
+}
+
+//
+// Public API
+//
+export async function ask_knowledge(request: AskRequest): Promise<AskResult> {
+  if (is_mock_mode()) {
+    return mock_ask(request)
+  }
+  return await cli_ask(request)
+}

--- a/src/lib/llm/enhance.ts
+++ b/src/lib/llm/enhance.ts
@@ -1,0 +1,284 @@
+//
+// enhance.ts - LLM-powered convergent refinement of existing knowledge
+//
+// Examines existing concepts, edges, episodes and proposes:
+// - Concept merges (redundant/overlapping)
+// - New edges (missing relationships)
+// - Observations (contradictions, gaps, insights about the graph itself)
+//
+// Does NOT add new topics — only refines what's already there.
+//
+
+import { spawn } from "node:child_process"
+import { is_mock_mode } from "./index.ts"
+
+export interface EnhanceRequest {
+  concepts:    { id: number; name: string; type: string }[]
+  edges:       { id: number; source_name: string; target_name: string; relation: string }[]
+  episodes:    { id: number; observation: string; context?: string; tags?: string[] }[]
+  focus?:      string
+  round:       number
+  total_rounds: number
+}
+
+export interface EnhanceResult {
+  operations: {
+    merge_concepts: { keep_name: string; remove_name: string; reason: string }[]
+    new_edges:      { source_name: string; target_name: string; relation: string }[]
+    observations:   { observation: string; context: string; tags: string[] }[]
+  }
+  reasoning: string
+}
+
+const ENHANCE_SCHEMA = JSON.stringify({
+  type: "object",
+  properties: {
+    operations: {
+      type: "object",
+      properties: {
+        merge_concepts: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              keep_name:   { type: "string", description: "Name of concept to keep" },
+              remove_name: { type: "string", description: "Name of redundant concept to remove" },
+              reason:      { type: "string", description: "Why these are the same concept" },
+            },
+            required: ["keep_name", "remove_name", "reason"],
+          },
+        },
+        new_edges: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              source_name: { type: "string", description: "Source concept name (must exist in provided concepts)" },
+              target_name: { type: "string", description: "Target concept name (must exist in provided concepts)" },
+              relation:    { type: "string", description: "Relationship type" },
+            },
+            required: ["source_name", "target_name", "relation"],
+          },
+        },
+        observations: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              observation: { type: "string", description: "What you noticed about the knowledge graph" },
+              context:     { type: "string", description: "What area this relates to" },
+              tags:        { type: "array", items: { type: "string" }, description: "Tags: contradiction, gap, redundancy, insight, quality" },
+            },
+            required: ["observation", "context", "tags"],
+          },
+        },
+      },
+      required: ["merge_concepts", "new_edges", "observations"],
+    },
+    reasoning: { type: "string", description: "Summary of refinement analysis" },
+  },
+  required: ["operations", "reasoning"],
+})
+
+const AGENT_NESTING_VARS = ["CLAUDECODE", "CLAUDE_CODE", "GEMINI_SESSION"]
+
+function clean_env(): Record<string, string | undefined> {
+  const env = { ...process.env }
+  for (const key of AGENT_NESTING_VARS) {
+    delete env[key]
+  }
+  return env
+}
+
+function run_cli(args: string[], stdin: string): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(args[0], args.slice(1), {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: clean_env(),
+    })
+
+    let stdout = ""
+    let stderr = ""
+
+    proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString() })
+    proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString() })
+
+    proc.on("error", (err: Error) => reject(err))
+    proc.on("close", (code: number | null) => resolve({ stdout, stderr, code: code ?? 1 }))
+
+    proc.stdin.write(stdin)
+    proc.stdin.end()
+  })
+}
+
+function build_system_prompt(): string {
+  return `You are a knowledge refinement system for Brane, an agent memory layer. Your job is CONVERGENT: sharpen existing knowledge without adding new topics.
+
+## Your Role
+You are NOT brainstorming or adding new topics. You are REFINING what's already there.
+
+## What to Produce
+
+1. **Merge Concepts** — find redundant/overlapping concepts
+   - Same thing with different names → merge
+   - keep_name and remove_name must exactly match concept names in the context
+
+2. **New Edges** — missing relationships between EXISTING concepts
+   - Implicit dependencies, undocumented connections
+   - source_name and target_name must exactly match existing concept names
+
+3. **Observations** — meta-knowledge about the graph itself
+   - Contradictions between episodes → tag "contradiction"
+   - Shallow areas needing more detail → tag "gap"
+   - Redundancy patterns → tag "redundancy"
+   - Quality insights → tag "quality", "insight"
+
+## Guidelines
+- Do NOT invent new concepts or topics
+- Only reference concepts that exist in the provided context
+- Be conservative with merges — only merge truly redundant concepts
+- 0-3 merges, 0-5 new edges, 1-5 observations per round
+- If the graph is already clean, say so and return empty operations
+
+Return your analysis as structured JSON.`
+}
+
+function build_user_prompt(request: EnhanceRequest): string {
+  const parts: string[] = []
+
+  if (request.round > 1) {
+    parts.push(`## Round ${request.round}/${request.total_rounds}`)
+    parts.push("Previous round's changes have been applied. Look deeper.")
+    parts.push("")
+  }
+
+  if (request.focus) {
+    parts.push(`## Focus Area: ${request.focus}`)
+    parts.push("Concentrate your refinement on concepts and relationships related to this topic.")
+    parts.push("")
+  }
+
+  if (request.concepts.length > 0) {
+    parts.push("## Concepts")
+    for (const c of request.concepts) {
+      parts.push(`- [#${c.id}] ${c.name} (${c.type})`)
+    }
+    parts.push("")
+  }
+
+  if (request.edges.length > 0) {
+    parts.push("## Relationships")
+    for (const e of request.edges) {
+      parts.push(`- [#${e.id}] ${e.source_name} → ${e.target_name} (${e.relation})`)
+    }
+    parts.push("")
+  }
+
+  if (request.episodes.length > 0) {
+    parts.push("## Episodes")
+    for (const ep of request.episodes) {
+      const tags = ep.tags?.length ? ` [${ep.tags.join(", ")}]` : ""
+      const ctx = ep.context ? ` — ${ep.context}` : ""
+      parts.push(`- [#${ep.id}] ${ep.observation}${ctx}${tags}`)
+    }
+    parts.push("")
+  }
+
+  if (request.concepts.length === 0) {
+    parts.push("(Empty knowledge graph — nothing to refine)")
+  }
+
+  parts.push("")
+  parts.push("Analyze this knowledge for redundancies, missing relationships, contradictions, and quality issues.")
+
+  return parts.join("\n")
+}
+
+//
+// Mock implementation
+//
+function mock_enhance(request: EnhanceRequest): EnhanceResult {
+  const ops: EnhanceResult["operations"] = {
+    merge_concepts: [],
+    new_edges: [],
+    observations: [],
+  }
+
+  // Mock: if 2+ concepts exist, suggest an edge between first two
+  if (request.concepts.length >= 2) {
+    ops.new_edges.push({
+      source_name: request.concepts[0].name,
+      target_name: request.concepts[1].name,
+      relation: "RELATES_TO",
+    })
+  }
+
+  // Always produce at least one observation
+  const focus = request.focus ?? "the knowledge graph"
+  ops.observations.push({
+    observation: `Refinement pass ${request.round} on ${focus}: graph structure looks reasonable`,
+    context: "enhance",
+    tags: ["quality"],
+  })
+
+  return {
+    operations: ops,
+    reasoning: `Mock enhance: analyzed ${request.concepts.length} concepts, ${request.edges.length} edges, ${request.episodes.length} episodes`,
+  }
+}
+
+//
+// Real implementation
+//
+async function cli_enhance(request: EnhanceRequest): Promise<EnhanceResult> {
+  const cli = process.env.BRANE_LLM_CLI ?? "claude"
+  const system_prompt = build_system_prompt()
+  const user_prompt = build_user_prompt(request)
+
+  const args = [
+    cli,
+    "-p",
+    "--output-format", "json",
+    "--system-prompt", system_prompt,
+    "--json-schema", ENHANCE_SCHEMA,
+    "--no-session-persistence",
+  ]
+
+  const result = await run_cli(args, user_prompt)
+
+  if (result.code !== 0) {
+    throw new Error(`${cli} exited with code ${result.code}: ${result.stderr || result.stdout}`)
+  }
+
+  let envelope: any
+  try {
+    envelope = JSON.parse(result.stdout)
+  } catch {
+    throw new Error(`${cli} returned invalid JSON: ${result.stdout.slice(0, 200)}`)
+  }
+
+  const output = envelope.structured_output ?? envelope.result ?? envelope
+  if (!output || typeof output !== "object") {
+    throw new Error(`${cli} returned no structured output`)
+  }
+
+  const ops = output.operations ?? {}
+  return {
+    operations: {
+      merge_concepts: Array.isArray(ops.merge_concepts) ? ops.merge_concepts : [],
+      new_edges:      Array.isArray(ops.new_edges) ? ops.new_edges : [],
+      observations:   Array.isArray(ops.observations) ? ops.observations : [],
+    },
+    reasoning: String(output.reasoning ?? ""),
+  }
+}
+
+//
+// Public API
+//
+export async function enhance_knowledge(request: EnhanceRequest): Promise<EnhanceResult> {
+  if (is_mock_mode()) {
+    return mock_enhance(request)
+  }
+  return await cli_enhance(request)
+}

--- a/src/lib/llm/enhance.ts
+++ b/src/lib/llm/enhance.ts
@@ -19,6 +19,7 @@ export interface EnhanceRequest {
   focus?:      string
   round:       number
   total_rounds: number
+  lens_prompt?: string
 }
 
 export interface EnhanceResult {
@@ -232,7 +233,10 @@ function mock_enhance(request: EnhanceRequest): EnhanceResult {
 //
 async function cli_enhance(request: EnhanceRequest): Promise<EnhanceResult> {
   const cli = process.env.BRANE_LLM_CLI ?? "claude"
-  const system_prompt = build_system_prompt()
+  let system_prompt = build_system_prompt()
+  if (request.lens_prompt) {
+    system_prompt += `\n\n## Active Lens\n${request.lens_prompt}`
+  }
   const user_prompt = build_user_prompt(request)
 
   const args = [

--- a/src/lib/llm/loop.ts
+++ b/src/lib/llm/loop.ts
@@ -1,0 +1,210 @@
+//
+// loop.ts - LLM-powered reflection for autonomous research loops
+//
+// Examines current knowledge vs goal, identifies gaps, proposes
+// web search queries to fill them. Detects convergence.
+//
+
+import { spawn } from "node:child_process"
+import { is_mock_mode } from "./index.ts"
+
+export interface ReflectRequest {
+  goal:           string
+  concepts:       { id: number; name: string; type: string }[]
+  episodes:       { id: number; observation: string; context?: string; tags?: string[] }[]
+  search_history: string[]   // queries already searched (avoid repeats)
+  round:          number
+  total_rounds:   number
+  lens_prompt?:   string
+}
+
+export interface ReflectResult {
+  gaps:       string[]    // what's missing from current knowledge
+  queries:    string[]    // web search queries to fill gaps
+  assessment: string      // current state of knowledge vs goal
+  converging: boolean     // true if knowledge is approaching completeness
+}
+
+const REFLECT_SCHEMA = JSON.stringify({
+  type: "object",
+  properties: {
+    gaps:       { type: "array", items: { type: "string" }, description: "Knowledge gaps relative to the goal" },
+    queries:    { type: "array", items: { type: "string" }, description: "Web search queries to fill gaps (2-4 queries)" },
+    assessment: { type: "string", description: "Assessment of current knowledge completeness" },
+    converging: { type: "boolean", description: "True if knowledge is approaching goal completeness" },
+  },
+  required: ["gaps", "queries", "assessment", "converging"],
+})
+
+const AGENT_NESTING_VARS = ["CLAUDECODE", "CLAUDE_CODE", "GEMINI_SESSION"]
+
+function clean_env(): Record<string, string | undefined> {
+  const env = { ...process.env }
+  for (const key of AGENT_NESTING_VARS) {
+    delete env[key]
+  }
+  return env
+}
+
+function run_cli(args: string[], stdin: string): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(args[0], args.slice(1), {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: clean_env(),
+    })
+
+    let stdout = ""
+    let stderr = ""
+
+    proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString() })
+    proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString() })
+
+    proc.on("error", (err: Error) => reject(err))
+    proc.on("close", (code: number | null) => resolve({ stdout, stderr, code: code ?? 1 }))
+
+    proc.stdin.write(stdin)
+    proc.stdin.end()
+  })
+}
+
+function build_system_prompt(lens_prompt?: string): string {
+  let prompt = `You are a research planning system for Brane, an agent memory layer. Given a research goal and current knowledge, you:
+
+1. Identify GAPS — what's missing relative to the goal
+2. Propose QUERIES — web search queries to fill those gaps (2-4 queries)
+3. ASSESS — how complete is current knowledge toward the goal
+4. Detect CONVERGENCE — is knowledge approaching completeness
+
+## Rules
+- Do NOT repeat queries from the search history
+- Queries should be specific and actionable
+- If knowledge is mostly complete, set converging=true
+- If no useful queries remain, return empty queries array and converging=true
+- Assessment should be 1-2 sentences`
+
+  if (lens_prompt) {
+    prompt += `\n\n## Active Lens\n${lens_prompt}`
+  }
+
+  prompt += `\n\nReturn your analysis as structured JSON.`
+  return prompt
+}
+
+function build_user_prompt(request: ReflectRequest): string {
+  const parts: string[] = []
+
+  parts.push(`## Research Goal\n${request.goal}\n`)
+  parts.push(`## Round ${request.round}/${request.total_rounds}\n`)
+
+  if (request.search_history.length > 0) {
+    parts.push("## Previous Searches (do NOT repeat)")
+    for (const q of request.search_history) {
+      parts.push(`- "${q}"`)
+    }
+    parts.push("")
+  }
+
+  if (request.concepts.length > 0) {
+    parts.push("## Current Knowledge (Concepts)")
+    for (const c of request.concepts.slice(0, 20)) {
+      parts.push(`- ${c.name} (${c.type})`)
+    }
+    if (request.concepts.length > 20) {
+      parts.push(`  ... and ${request.concepts.length - 20} more`)
+    }
+    parts.push("")
+  }
+
+  if (request.episodes.length > 0) {
+    parts.push("## Current Knowledge (Episodes)")
+    for (const ep of request.episodes.slice(0, 15)) {
+      parts.push(`- ${ep.observation}`)
+    }
+    if (request.episodes.length > 15) {
+      parts.push(`  ... and ${request.episodes.length - 15} more`)
+    }
+    parts.push("")
+  }
+
+  if (request.concepts.length === 0 && request.episodes.length === 0) {
+    parts.push("(No relevant knowledge yet — this is the first round)")
+  }
+
+  parts.push("\nWhat gaps exist? What should be searched next?")
+
+  return parts.join("\n")
+}
+
+//
+// Mock implementation
+//
+function mock_reflect(request: ReflectRequest): ReflectResult {
+  const round = request.round
+  const converging = round >= 2 || request.concepts.length > 5
+
+  return {
+    gaps: converging
+      ? ["Minor details remain"]
+      : [`Core understanding of "${request.goal}" needed`, "Practical examples missing"],
+    queries: converging
+      ? []
+      : [`${request.goal} overview`, `${request.goal} best practices`].filter(q => !request.search_history.includes(q)),
+    assessment: converging
+      ? `Good coverage of "${request.goal}" after ${round} rounds.`
+      : `Early stage research on "${request.goal}". Key concepts not yet identified.`,
+    converging,
+  }
+}
+
+//
+// Real implementation
+//
+async function cli_reflect(request: ReflectRequest): Promise<ReflectResult> {
+  const cli = process.env.BRANE_LLM_CLI ?? "claude"
+  const system_prompt = build_system_prompt(request.lens_prompt)
+  const user_prompt = build_user_prompt(request)
+
+  const args = [
+    cli,
+    "-p",
+    "--output-format", "json",
+    "--system-prompt", system_prompt,
+    "--json-schema", REFLECT_SCHEMA,
+    "--no-session-persistence",
+  ]
+
+  const result = await run_cli(args, user_prompt)
+
+  if (result.code !== 0) {
+    throw new Error(`${cli} exited with code ${result.code}: ${result.stderr || result.stdout}`)
+  }
+
+  let envelope: any
+  try {
+    envelope = JSON.parse(result.stdout)
+  } catch {
+    throw new Error(`${cli} returned invalid JSON: ${result.stdout.slice(0, 200)}`)
+  }
+
+  const output = envelope.structured_output ?? envelope.result ?? envelope
+  if (!output || typeof output !== "object") {
+    throw new Error(`${cli} returned no structured output`)
+  }
+
+  return {
+    gaps:       Array.isArray(output.gaps) ? output.gaps : [],
+    queries:    Array.isArray(output.queries) ? output.queries : [],
+    assessment: String(output.assessment ?? ""),
+    converging: !!output.converging,
+  }
+}
+
+//
+// Public API
+//
+export async function reflect_on_goal(request: ReflectRequest): Promise<ReflectResult> {
+  if (is_mock_mode()) {
+    return mock_reflect(request)
+  }
+  return await cli_reflect(request)
+}

--- a/src/lib/llm/storm.ts
+++ b/src/lib/llm/storm.ts
@@ -17,6 +17,7 @@ export interface StormRequest {
   episodes:    { id: number; observation: string; context?: string; tags?: string[] }[]
   round:       number     // current round (1-based)
   total_rounds: number
+  lens_prompt?: string
 }
 
 export interface StormResult {
@@ -148,6 +149,11 @@ You are NOT retrieving or summarizing — you are GENERATING new knowledge by th
 Return your brainstorm as structured JSON.`
 }
 
+function append_lens(base: string, lens_prompt?: string): string {
+  if (!lens_prompt) return base
+  return base + `\n\n## Active Lens\n${lens_prompt}`
+}
+
 function build_user_prompt(request: StormRequest): string {
   const parts: string[] = []
 
@@ -244,7 +250,7 @@ function mock_storm(request: StormRequest): StormResult {
 //
 async function cli_storm(request: StormRequest): Promise<StormResult> {
   const cli = process.env.BRANE_LLM_CLI ?? "claude"
-  const system_prompt = build_system_prompt()
+  const system_prompt = append_lens(build_system_prompt(), request.lens_prompt)
   const user_prompt = build_user_prompt(request)
 
   const args = [

--- a/src/lib/llm/storm.ts
+++ b/src/lib/llm/storm.ts
@@ -1,0 +1,294 @@
+//
+// storm.ts - LLM-powered divergent brainstorming over accumulated knowledge
+//
+// Takes existing context (concepts, edges, episodes) and generates
+// new knowledge: concepts, edges, episodes, plus suggestions for
+// next actions (questions, sources, lenses).
+//
+
+import { spawn } from "node:child_process"
+import { is_mock_mode } from "./index.ts"
+
+export interface StormRequest {
+  seed?:       string     // optional topic seed
+  input?:      string     // optional document to brainstorm against
+  concepts:    { id: number; name: string; type: string }[]
+  edges:       { id: number; source_name: string; target_name: string; relation: string }[]
+  episodes:    { id: number; observation: string; context?: string; tags?: string[] }[]
+  round:       number     // current round (1-based)
+  total_rounds: number
+}
+
+export interface StormResult {
+  concepts: { name: string; type: string }[]
+  edges:    { source_name: string; target_name: string; relation: string }[]
+  episodes: { observation: string; context: string; tags: string[] }[]
+  suggestions: { kind: "question" | "source" | "lens"; value: string; reason: string }[]
+  reasoning: string
+}
+
+const STORM_SCHEMA = JSON.stringify({
+  type: "object",
+  properties: {
+    concepts: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          name: { type: "string", description: "PascalCase name for the concept" },
+          type: { type: "string", description: "Concept type: Entity, Caveat, Rule, or custom" },
+        },
+        required: ["name", "type"],
+      },
+    },
+    edges: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          source_name: { type: "string", description: "Exact name of source concept (must be in concepts list or existing context)" },
+          target_name: { type: "string", description: "Exact name of target concept (must be in concepts list or existing context)" },
+          relation:    { type: "string", description: "Relationship type" },
+        },
+        required: ["source_name", "target_name", "relation"],
+      },
+    },
+    episodes: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          observation: { type: "string", description: "Insight, question, hypothesis, or gap identified" },
+          context:     { type: "string", description: "What prompted this observation" },
+          tags:        { type: "array", items: { type: "string" }, description: "Tags: question, hypothesis, gap, insight, contradiction, connection" },
+        },
+        required: ["observation", "context", "tags"],
+      },
+    },
+    suggestions: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          kind:   { type: "string", enum: ["question", "source", "lens"], description: "Type of suggestion" },
+          value:  { type: "string", description: "The suggestion itself" },
+          reason: { type: "string", description: "Why this would be valuable" },
+        },
+        required: ["kind", "value", "reason"],
+      },
+    },
+    reasoning: { type: "string", description: "Explanation of brainstorming process and key themes" },
+  },
+  required: ["concepts", "edges", "episodes", "suggestions", "reasoning"],
+})
+
+const AGENT_NESTING_VARS = ["CLAUDECODE", "CLAUDE_CODE", "GEMINI_SESSION"]
+
+function clean_env(): Record<string, string | undefined> {
+  const env = { ...process.env }
+  for (const key of AGENT_NESTING_VARS) {
+    delete env[key]
+  }
+  return env
+}
+
+function run_cli(args: string[], stdin: string): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(args[0], args.slice(1), {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: clean_env(),
+    })
+
+    let stdout = ""
+    let stderr = ""
+
+    proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString() })
+    proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString() })
+
+    proc.on("error", (err: Error) => reject(err))
+    proc.on("close", (code: number | null) => resolve({ stdout, stderr, code: code ?? 1 }))
+
+    proc.stdin.write(stdin)
+    proc.stdin.end()
+  })
+}
+
+function build_system_prompt(): string {
+  return `You are a divergent thinking system for Brane, an agent memory layer. Your job is to brainstorm: find gaps, surface blind spots, propose connections, and question assumptions.
+
+## Your Role
+You are NOT retrieving or summarizing — you are GENERATING new knowledge by thinking creatively about what's already known.
+
+## What to Produce
+
+1. **New Concepts** — things that SHOULD exist in the graph but don't yet
+   - Missing abstractions, implicit dependencies, unnamed patterns
+   - PascalCase names, typed as Entity, Caveat, Rule, or custom
+
+2. **New Edges** — relationships that connect existing OR new concepts
+   - Hidden dependencies, contradictions, alternatives
+   - source_name and target_name must match concept names (existing or new)
+
+3. **New Episodes** — insights, questions, hypotheses, gaps
+   - Tag with: question, hypothesis, gap, insight, contradiction, connection
+   - These capture your THINKING, not just facts
+
+4. **Suggestions** — recommended next actions for the human
+   - "question": things worth investigating with \`brane ask\`
+   - "source": content worth digesting with \`brane digest\`
+   - "lens": perspectives worth exploring
+
+## Guidelines
+- Be creative but grounded — every idea should connect to existing knowledge
+- Prefer surprising connections over obvious ones
+- Surface contradictions and tensions explicitly
+- 3-8 new concepts, 2-6 edges, 3-8 episodes, 2-5 suggestions
+- Quality over quantity — each item should be genuinely useful
+
+Return your brainstorm as structured JSON.`
+}
+
+function build_user_prompt(request: StormRequest): string {
+  const parts: string[] = []
+
+  if (request.round > 1) {
+    parts.push(`## Round ${request.round}/${request.total_rounds}`)
+    parts.push("Go deeper. The context below includes items from previous rounds.")
+    parts.push("Find second-order connections, challenge earlier assumptions, and explore edges.")
+    parts.push("")
+  }
+
+  if (request.seed) {
+    parts.push(`## Seed Topic: ${request.seed}`)
+    parts.push("")
+  }
+
+  if (request.input) {
+    const truncated = request.input.length > 50000
+      ? request.input.slice(0, 50000) + "\n\n[... truncated ...]"
+      : request.input
+    parts.push("## Input Document")
+    parts.push(truncated)
+    parts.push("")
+  }
+
+  if (request.concepts.length > 0) {
+    parts.push("## Existing Concepts")
+    for (const c of request.concepts) {
+      parts.push(`- [#${c.id}] ${c.name} (${c.type})`)
+    }
+    parts.push("")
+  }
+
+  if (request.edges.length > 0) {
+    parts.push("## Existing Relationships")
+    for (const e of request.edges) {
+      parts.push(`- [#${e.id}] ${e.source_name} → ${e.target_name} (${e.relation})`)
+    }
+    parts.push("")
+  }
+
+  if (request.episodes.length > 0) {
+    parts.push("## Existing Memories")
+    for (const ep of request.episodes) {
+      const tags = ep.tags?.length ? ` [${ep.tags.join(", ")}]` : ""
+      const ctx = ep.context ? ` — ${ep.context}` : ""
+      parts.push(`- [#${ep.id}] ${ep.observation}${ctx}${tags}`)
+    }
+    parts.push("")
+  }
+
+  if (request.concepts.length === 0 && request.episodes.length === 0 && !request.input) {
+    parts.push("(Empty knowledge graph — brainstorm from scratch based on the seed topic)")
+  }
+
+  parts.push("")
+  parts.push("Now brainstorm: what's missing? What connections haven't been made? What questions should be asked?")
+
+  return parts.join("\n")
+}
+
+//
+// Mock implementation
+//
+function mock_storm(request: StormRequest): StormResult {
+  const seed = request.seed ?? "general"
+  const name = seed
+    .split(/\s+/)
+    .slice(0, 2)
+    .map(s => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase())
+    .join("")
+
+  return {
+    concepts: [
+      { name: `${name}Gap`, type: "Caveat" },
+      { name: `${name}Pattern`, type: "Entity" },
+    ],
+    edges: [
+      { source_name: `${name}Gap`, target_name: `${name}Pattern`, relation: "MOTIVATES" },
+    ],
+    episodes: [
+      { observation: `Brainstorming about ${seed} reveals potential gaps in coverage`, context: "storm", tags: ["gap", "insight"] },
+      { observation: `The ${seed} area may benefit from deeper investigation`, context: "storm", tags: ["question"] },
+    ],
+    suggestions: [
+      { kind: "question", value: `What are the edge cases in ${seed}?`, reason: "Gap in current knowledge" },
+      { kind: "source", value: `Look for documentation on ${seed} best practices`, reason: "Would strengthen the knowledge graph" },
+    ],
+    reasoning: `Mock storm: generated speculative concepts and suggestions around "${seed}"`,
+  }
+}
+
+//
+// Real implementation
+//
+async function cli_storm(request: StormRequest): Promise<StormResult> {
+  const cli = process.env.BRANE_LLM_CLI ?? "claude"
+  const system_prompt = build_system_prompt()
+  const user_prompt = build_user_prompt(request)
+
+  const args = [
+    cli,
+    "-p",
+    "--output-format", "json",
+    "--system-prompt", system_prompt,
+    "--json-schema", STORM_SCHEMA,
+    "--no-session-persistence",
+  ]
+
+  const result = await run_cli(args, user_prompt)
+
+  if (result.code !== 0) {
+    throw new Error(`${cli} exited with code ${result.code}: ${result.stderr || result.stdout}`)
+  }
+
+  let envelope: any
+  try {
+    envelope = JSON.parse(result.stdout)
+  } catch {
+    throw new Error(`${cli} returned invalid JSON: ${result.stdout.slice(0, 200)}`)
+  }
+
+  const output = envelope.structured_output ?? envelope.result ?? envelope
+  if (!output || typeof output !== "object") {
+    throw new Error(`${cli} returned no structured output`)
+  }
+
+  return {
+    concepts:    Array.isArray(output.concepts) ? output.concepts : [],
+    edges:       Array.isArray(output.edges) ? output.edges : [],
+    episodes:    Array.isArray(output.episodes) ? output.episodes : [],
+    suggestions: Array.isArray(output.suggestions) ? output.suggestions : [],
+    reasoning:   String(output.reasoning ?? ""),
+  }
+}
+
+//
+// Public API
+//
+export async function storm_knowledge(request: StormRequest): Promise<StormResult> {
+  if (is_mock_mode()) {
+    return mock_storm(request)
+  }
+  return await cli_storm(request)
+}

--- a/src/lib/llm/tldr.ts
+++ b/src/lib/llm/tldr.ts
@@ -1,0 +1,226 @@
+//
+// tldr.ts - LLM-powered knowledge outline with synopses
+//
+// Takes graph contents and produces a structured topical outline
+// with one-line synopses per concept.
+//
+
+import { spawn } from "node:child_process"
+import { is_mock_mode } from "./index.ts"
+
+export interface TldrRequest {
+  concepts:    { id: number; name: string; type: string }[]
+  edges:       { id: number; source_name: string; target_name: string; relation: string }[]
+  episodes:    { id: number; observation: string; context?: string; tags?: string[]; timestamp?: string }[]
+  focus?:      string
+  lens_prompt?: string
+}
+
+export interface TldrTopic {
+  title:   string
+  items:   string[]
+}
+
+export interface TldrResult {
+  topics:    TldrTopic[]
+  learnings: string[]    // recent episodes formatted as one-liners
+  reasoning: string
+}
+
+const TLDR_SCHEMA = JSON.stringify({
+  type: "object",
+  properties: {
+    topics: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "Topic heading" },
+          items: { type: "array", items: { type: "string" }, description: "One-line synopses under this topic" },
+        },
+        required: ["title", "items"],
+      },
+    },
+    learnings: {
+      type: "array",
+      items: { type: "string" },
+      description: "Recent episodes/insights formatted as one-liners",
+    },
+    reasoning: { type: "string", description: "Brief note on organization choices" },
+  },
+  required: ["topics", "learnings", "reasoning"],
+})
+
+const AGENT_NESTING_VARS = ["CLAUDECODE", "CLAUDE_CODE", "GEMINI_SESSION"]
+
+function clean_env(): Record<string, string | undefined> {
+  const env = { ...process.env }
+  for (const key of AGENT_NESTING_VARS) {
+    delete env[key]
+  }
+  return env
+}
+
+function run_cli(args: string[], stdin: string): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(args[0], args.slice(1), {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: clean_env(),
+    })
+
+    let stdout = ""
+    let stderr = ""
+
+    proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString() })
+    proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString() })
+
+    proc.on("error", (err: Error) => reject(err))
+    proc.on("close", (code: number | null) => resolve({ stdout, stderr, code: code ?? 1 }))
+
+    proc.stdin.write(stdin)
+    proc.stdin.end()
+  })
+}
+
+function build_system_prompt(lens_prompt?: string): string {
+  let prompt = `You are a knowledge organizer for Brane, an agent memory layer. Given concepts, relationships, and episodes, produce a structured topical outline.
+
+## Rules
+1. Group related concepts into 2-6 topics with clear headings
+2. Each item under a topic is a one-line synopsis (not just the name)
+3. Synopses should convey what the concept IS or DOES, not just name it
+4. Recent episodes go in "learnings" as one-liners with context
+5. If focused on a topic, only include relevant items
+6. Be concise — this is a quick-glance overview`
+
+  if (lens_prompt) {
+    prompt += `\n\n## Active Lens\n${lens_prompt}`
+  }
+
+  prompt += `\n\nReturn your outline as structured JSON.`
+  return prompt
+}
+
+function build_user_prompt(request: TldrRequest): string {
+  const parts: string[] = []
+
+  if (request.focus) {
+    parts.push(`## Focus: ${request.focus}`)
+    parts.push("Only include items relevant to this topic.")
+    parts.push("")
+  }
+
+  if (request.concepts.length > 0) {
+    parts.push("## Concepts")
+    for (const c of request.concepts) {
+      parts.push(`- ${c.name} (${c.type})`)
+    }
+    parts.push("")
+  }
+
+  if (request.edges.length > 0) {
+    parts.push("## Relationships")
+    for (const e of request.edges) {
+      parts.push(`- ${e.source_name} → ${e.target_name} (${e.relation})`)
+    }
+    parts.push("")
+  }
+
+  if (request.episodes.length > 0) {
+    parts.push("## Episodes")
+    for (const ep of request.episodes) {
+      const ctx = ep.context ? ` — ${ep.context}` : ""
+      parts.push(`- ${ep.observation}${ctx}`)
+    }
+    parts.push("")
+  }
+
+  if (request.concepts.length === 0 && request.episodes.length === 0) {
+    parts.push("(Empty knowledge graph)")
+  }
+
+  parts.push("\nOrganize this into a topical outline with synopses.")
+  return parts.join("\n")
+}
+
+//
+// Mock implementation
+//
+function mock_tldr(request: TldrRequest): TldrResult {
+  const topics: TldrTopic[] = []
+
+  if (request.concepts.length > 0) {
+    // Group by type
+    const by_type: Record<string, string[]> = {}
+    for (const c of request.concepts) {
+      const t = c.type || "General"
+      if (!by_type[t]) by_type[t] = []
+      by_type[t].push(`${c.name} — a ${c.type.toLowerCase()} in the knowledge graph`)
+    }
+    for (const [type, items] of Object.entries(by_type)) {
+      topics.push({ title: type, items })
+    }
+  }
+
+  const learnings = request.episodes
+    .slice(0, 5)
+    .map(ep => ep.observation)
+
+  return {
+    topics,
+    learnings,
+    reasoning: `Organized ${request.concepts.length} concepts into ${topics.length} topics by type`,
+  }
+}
+
+//
+// Real implementation
+//
+async function cli_tldr(request: TldrRequest): Promise<TldrResult> {
+  const cli = process.env.BRANE_LLM_CLI ?? "claude"
+  const system_prompt = build_system_prompt(request.lens_prompt)
+  const user_prompt = build_user_prompt(request)
+
+  const args = [
+    cli,
+    "-p",
+    "--output-format", "json",
+    "--system-prompt", system_prompt,
+    "--json-schema", TLDR_SCHEMA,
+    "--no-session-persistence",
+  ]
+
+  const result = await run_cli(args, user_prompt)
+
+  if (result.code !== 0) {
+    throw new Error(`${cli} exited with code ${result.code}: ${result.stderr || result.stdout}`)
+  }
+
+  let envelope: any
+  try {
+    envelope = JSON.parse(result.stdout)
+  } catch {
+    throw new Error(`${cli} returned invalid JSON: ${result.stdout.slice(0, 200)}`)
+  }
+
+  const output = envelope.structured_output ?? envelope.result ?? envelope
+  if (!output || typeof output !== "object") {
+    throw new Error(`${cli} returned no structured output`)
+  }
+
+  return {
+    topics:    Array.isArray(output.topics) ? output.topics : [],
+    learnings: Array.isArray(output.learnings) ? output.learnings : [],
+    reasoning: String(output.reasoning ?? ""),
+  }
+}
+
+//
+// Public API
+//
+export async function tldr_knowledge(request: TldrRequest): Promise<TldrResult> {
+  if (is_mock_mode()) {
+    return mock_tldr(request)
+  }
+  return await cli_tldr(request)
+}

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -181,3 +181,140 @@ export function resolve_lens_paths(lens_name?: string): LensPaths {
     lens_name:    name
   }
 }
+
+//
+// Lens prompt management
+//
+
+export interface LensPromptInfo {
+  name:        string
+  prompt:      string
+  description: string
+  active:      boolean
+  created_at:  string
+}
+
+// Ensure lens_prompts table exists (idempotent, for cases where state.db was created before this feature)
+function ensure_lens_prompts_table(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS lens_prompts (
+      name        TEXT PRIMARY KEY,
+      prompt      TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      active      INTEGER NOT NULL DEFAULT 0,
+      created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `)
+}
+
+// Save or update a lens prompt
+export function set_lens_prompt(name: string, prompt: string, description?: string): boolean {
+  const db = open_state()
+  if (!db) return false
+  try {
+    ensure_lens_prompts_table(db)
+    db.run(
+      "INSERT OR REPLACE INTO lens_prompts (name, prompt, description, active, created_at) VALUES (?, ?, ?, COALESCE((SELECT active FROM lens_prompts WHERE name = ?), 0), datetime('now'))",
+      [name, prompt, description ?? "", name],
+    )
+    db.close()
+    return true
+  } catch {
+    db.close()
+    return false
+  }
+}
+
+// Get a single lens prompt
+export function get_lens_prompt(name: string): LensPromptInfo | null {
+  const db = open_state()
+  if (!db) return null
+  try {
+    ensure_lens_prompts_table(db)
+    const row = db.query("SELECT name, prompt, description, active, created_at FROM lens_prompts WHERE name = ?").get(name) as any
+    db.close()
+    if (!row) return null
+    return { name: row.name, prompt: row.prompt, description: row.description, active: !!row.active, created_at: row.created_at }
+  } catch {
+    db.close()
+    return null
+  }
+}
+
+// Delete a lens prompt
+export function delete_lens_prompt(name: string): boolean {
+  const db = open_state()
+  if (!db) return false
+  try {
+    ensure_lens_prompts_table(db)
+    db.run("DELETE FROM lens_prompts WHERE name = ?", [name])
+    db.close()
+    return true
+  } catch {
+    db.close()
+    return false
+  }
+}
+
+// Activate a lens prompt
+export function activate_lens_prompt(name: string): boolean {
+  const db = open_state()
+  if (!db) return false
+  try {
+    ensure_lens_prompts_table(db)
+    const row = db.query("SELECT 1 FROM lens_prompts WHERE name = ?").get(name)
+    if (!row) { db.close(); return false }
+    db.run("UPDATE lens_prompts SET active = 1 WHERE name = ?", [name])
+    db.close()
+    return true
+  } catch {
+    db.close()
+    return false
+  }
+}
+
+// Deactivate a lens prompt
+export function deactivate_lens_prompt(name: string): boolean {
+  const db = open_state()
+  if (!db) return false
+  try {
+    ensure_lens_prompts_table(db)
+    db.run("UPDATE lens_prompts SET active = 0 WHERE name = ?", [name])
+    db.close()
+    return true
+  } catch {
+    db.close()
+    return false
+  }
+}
+
+// List all lens prompts
+export function list_lens_prompts(): LensPromptInfo[] {
+  const db = open_state()
+  if (!db) return []
+  try {
+    ensure_lens_prompts_table(db)
+    const rows = db.query("SELECT name, prompt, description, active, created_at FROM lens_prompts ORDER BY name").all() as any[]
+    db.close()
+    return rows.map(r => ({ name: r.name, prompt: r.prompt, description: r.description, active: !!r.active, created_at: r.created_at }))
+  } catch {
+    db.close()
+    return []
+  }
+}
+
+// Get combined prompt from all active lens prompts
+export function get_active_lens_prompts(): string | undefined {
+  const db = open_state()
+  if (!db) return undefined
+  try {
+    ensure_lens_prompts_table(db)
+    const rows = db.query("SELECT name, prompt FROM lens_prompts WHERE active = 1 ORDER BY name").all() as { name: string; prompt: string }[]
+    db.close()
+    if (rows.length === 0) return undefined
+    return rows.map(r => `## Lens: ${r.name}\n${r.prompt}`).join("\n\n")
+  } catch {
+    db.close()
+    return undefined
+  }
+}

--- a/src/lib/web-search.ts
+++ b/src/lib/web-search.ts
@@ -1,0 +1,116 @@
+//
+// web-search.ts - web search for loop's research cycles
+//
+// Shells out to curl for DuckDuckGo HTML search, extracts URLs.
+// Mock mode returns deterministic results for testing.
+//
+
+import { spawn } from "node:child_process"
+
+export interface SearchResult {
+  query:   string
+  urls:    string[]
+  error?:  string
+}
+
+const MAX_URLS_PER_QUERY = 3
+
+//
+// Mock mode check
+//
+function is_mock_search(): boolean {
+  return process.env.BRANE_LLM_MOCK === "1" || process.env.BRANE_SEARCH_MOCK === "1"
+}
+
+//
+// Real search: DuckDuckGo HTML lite
+//
+async function ddg_search(query: string): Promise<string[]> {
+  const encoded = encodeURIComponent(query)
+  const url = `https://html.duckduckgo.com/html/?q=${encoded}`
+
+  const result = await new Promise<{ stdout: string; code: number }>((resolve, reject) => {
+    const proc = spawn("curl", [
+      "-sL",
+      "--max-time", "10",
+      "--proto", "=http,https",
+      "-A", "Mozilla/5.0 (compatible; brane/1.0)",
+      url,
+    ], { stdio: ["pipe", "pipe", "pipe"] })
+
+    let stdout = ""
+    proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString() })
+    proc.on("error", (err: Error) => reject(err))
+    proc.on("close", (code: number | null) => resolve({ stdout, code: code ?? 1 }))
+  })
+
+  if (result.code !== 0 || !result.stdout) {
+    return []
+  }
+
+  // Extract URLs from DuckDuckGo HTML results
+  // DDG lite wraps result links in <a rel="nofollow" class="result__a" href="...">
+  const urls: string[] = []
+  const regex = /href="(https?:\/\/[^"]+)"/g
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(result.stdout)) !== null) {
+    const href = match[1]
+    // Skip DDG internal links and common noise
+    if (href.includes("duckduckgo.com")) continue
+    if (href.includes("duck.co")) continue
+    if (href.includes("ad_domain")) continue
+    // DDG lite wraps URLs in redirect: //duckduckgo.com/l/?uddg=ENCODED_URL
+    // Direct links are what we want
+    if (!urls.includes(href)) {
+      urls.push(href)
+    }
+    if (urls.length >= MAX_URLS_PER_QUERY) break
+  }
+
+  // Also try extracting from uddg= parameter (DDG redirect URLs)
+  if (urls.length < MAX_URLS_PER_QUERY) {
+    const uddg_regex = /uddg=([^&"]+)/g
+    while ((match = uddg_regex.exec(result.stdout)) !== null && urls.length < MAX_URLS_PER_QUERY) {
+      try {
+        const decoded = decodeURIComponent(match[1])
+        if (decoded.startsWith("http") && !decoded.includes("duckduckgo.com") && !urls.includes(decoded)) {
+          urls.push(decoded)
+        }
+      } catch {
+        // skip malformed URLs
+      }
+    }
+  }
+
+  return urls
+}
+
+//
+// Mock search
+//
+function mock_search(query: string): string[] {
+  // Return deterministic mock URLs based on query hash
+  const hash = query.split("").reduce((h, c) => ((h << 5) - h + c.charCodeAt(0)) | 0, 0)
+  const idx = Math.abs(hash) % 100
+  return [
+    `https://example.com/article-${idx}`,
+    `https://example.com/guide-${idx + 1}`,
+  ]
+}
+
+//
+// Public API
+//
+export async function web_search(query: string): Promise<SearchResult> {
+  if (is_mock_search()) {
+    return { query, urls: mock_search(query) }
+  }
+
+  try {
+    const urls = await ddg_search(query)
+    return { query, urls }
+  } catch (e: any) {
+    return { query, urls: [], error: e.message ?? "search failed" }
+  }
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -227,6 +227,17 @@ const TOOLS: McpTool[] = [
     },
   },
   {
+    name: "rebuild",
+    description: "Re-extract all digested sources through current active lenses. Clears digest records and re-processes each source chronologically. Use after changing active lenses.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        lens:    { type: "string", description: "Override lens prompt for rebuild" },
+        dry_run: { type: "boolean", description: "Show what would be rebuilt" },
+      },
+    },
+  },
+  {
     name: "lens_prompt_set",
     description: "Create or update a lens prompt (cognitive filter). Lens prompts shape how digest, storm, enhance, and ask process information. Use lens_prompt_on to activate after creating.",
     inputSchema: {
@@ -482,6 +493,7 @@ const TOOL_ROUTES: Record<string, string> = {
   enhance:          "/calabi/enhance",
   loop:             "/calabi/loop",
   loop_list:        "/calabi/loop",
+  rebuild:          "/calabi/rebuild",
   lens_prompt_set:  "/lens/prompt",
   lens_prompt_on:   "/lens/prompt",
   lens_prompt_off:  "/lens/prompt",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -205,6 +205,28 @@ const TOOLS: McpTool[] = [
     },
   },
   {
+    name: "loop",
+    description: "Autonomous goal-directed research. Give a goal and brane reflects on gaps, searches the web, digests findings, and repeats until convergent. Rate-limited.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        goal:    { type: "string", description: "Research goal" },
+        rounds:  { type: "number", description: "Max rounds (default 5, max 10)" },
+        resume:  { type: "string", description: "Resume a paused loop by ID" },
+        dry_run: { type: "boolean", description: "Preview without searching/digesting" },
+      },
+      required: ["goal"],
+    },
+  },
+  {
+    name: "loop_list",
+    description: "List all research loops with their status.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
     name: "lens_prompt_set",
     description: "Create or update a lens prompt (cognitive filter). Lens prompts shape how digest, storm, enhance, and ask process information. Use lens_prompt_on to activate after creating.",
     inputSchema: {
@@ -458,6 +480,8 @@ const TOOL_ROUTES: Record<string, string> = {
   ask:              "/calabi/ask",
   storm:            "/calabi/storm",
   enhance:          "/calabi/enhance",
+  loop:             "/calabi/loop",
+  loop_list:        "/calabi/loop",
   lens_prompt_set:  "/lens/prompt",
   lens_prompt_on:   "/lens/prompt",
   lens_prompt_off:  "/lens/prompt",
@@ -1414,7 +1438,8 @@ async function handle_tools_call(params: Record<string, unknown>): Promise<unkno
   }
 
   // Inject action for lens_prompt_* tools
-  if (name === "lens_prompt_set") args.action = "set"
+  if (name === "loop_list") args.action = "list"
+  else if (name === "lens_prompt_set") args.action = "set"
   else if (name === "lens_prompt_on") args.action = "on"
   else if (name === "lens_prompt_off") args.action = "off"
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -162,6 +162,22 @@ const TOOLS: McpTool[] = [
     },
   },
   {
+    name: "ask",
+    description: "Ask a question and get a synthesized answer from the knowledge graph. Vector-searches concepts and episodes for relevant context, enriches with graph neighbors, then uses LLM to synthesize an answer with citations. Rate-limited.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        question: { type: "string", description: "The question to answer" },
+        limit:    { type: "number", description: "Max context items to load (default 20)" },
+        agent_id: { type: "string", description: "Filter by agent ID" },
+        after:    { type: "string", description: "Only use knowledge after this ISO timestamp" },
+        before:   { type: "string", description: "Only use knowledge before this ISO timestamp" },
+        lens:     { type: "string", description: "Lens prompt to shape the answer" },
+      },
+      required: ["question"],
+    },
+  },
+  {
     name: "ingest_sessions",
     description: "Passively ingest Claude Code session logs into episodic memory. Parses JSONL conversation logs to extract human↔assistant exchanges and store them as episodes. Tracks ingested sessions to avoid duplicates.",
     inputSchema: {
@@ -377,6 +393,7 @@ const TOOL_ROUTES: Record<string, string> = {
   relate:           "/mind/edges/create",
   ingest_sessions:  "/calabi/ingest-sessions",
   digest:           "/calabi/digest",
+  ask:              "/calabi/ask",
 }
 
 //

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -205,6 +205,41 @@ const TOOLS: McpTool[] = [
     },
   },
   {
+    name: "lens_prompt_set",
+    description: "Create or update a lens prompt (cognitive filter). Lens prompts shape how digest, storm, enhance, and ask process information. Use lens_prompt_on to activate after creating.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name:        { type: "string", description: "Lens name" },
+        prompt:      { type: "string", description: "The lens prompt text" },
+        description: { type: "string", description: "Optional description" },
+      },
+      required: ["name", "prompt"],
+    },
+  },
+  {
+    name: "lens_prompt_on",
+    description: "Activate a lens prompt. Active lenses shape all future digest/storm/enhance/ask operations. Multiple lenses can be active simultaneously.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Lens name to activate" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "lens_prompt_off",
+    description: "Deactivate a lens prompt.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Lens name to deactivate" },
+      },
+      required: ["name"],
+    },
+  },
+  {
     name: "ingest_sessions",
     description: "Passively ingest Claude Code session logs into episodic memory. Parses JSONL conversation logs to extract human↔assistant exchanges and store them as episodes. Tracks ingested sessions to avoid duplicates.",
     inputSchema: {
@@ -423,6 +458,9 @@ const TOOL_ROUTES: Record<string, string> = {
   ask:              "/calabi/ask",
   storm:            "/calabi/storm",
   enhance:          "/calabi/enhance",
+  lens_prompt_set:  "/lens/prompt",
+  lens_prompt_on:   "/lens/prompt",
+  lens_prompt_off:  "/lens/prompt",
 }
 
 //
@@ -1374,6 +1412,11 @@ async function handle_tools_call(params: Record<string, unknown>): Promise<unkno
       args.agent_id = mcp_agent_id
     }
   }
+
+  // Inject action for lens_prompt_* tools
+  if (name === "lens_prompt_set") args.action = "set"
+  else if (name === "lens_prompt_on") args.action = "on"
+  else if (name === "lens_prompt_off") args.action = "off"
 
   // Use custom handler if available, otherwise dispatch via route
   try {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -192,6 +192,19 @@ const TOOLS: McpTool[] = [
     },
   },
   {
+    name: "enhance",
+    description: "Convergent refinement of existing knowledge. Merges duplicate concepts, adds missing edges between related concepts, and surfaces contradictions and quality issues. Does NOT add new topics — only refines what's there. Rate-limited.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        focus:   { type: "string", description: "Topic to focus refinement on (optional)" },
+        rounds:  { type: "number", description: "Iterative refinement rounds (default 1, max 5)" },
+        limit:   { type: "number", description: "Max context items (default 30)" },
+        dry_run: { type: "boolean", description: "Preview without writing" },
+      },
+    },
+  },
+  {
     name: "ingest_sessions",
     description: "Passively ingest Claude Code session logs into episodic memory. Parses JSONL conversation logs to extract human↔assistant exchanges and store them as episodes. Tracks ingested sessions to avoid duplicates.",
     inputSchema: {
@@ -409,6 +422,7 @@ const TOOL_ROUTES: Record<string, string> = {
   digest:           "/calabi/digest",
   ask:              "/calabi/ask",
   storm:            "/calabi/storm",
+  enhance:          "/calabi/enhance",
 }
 
 //

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -238,6 +238,17 @@ const TOOLS: McpTool[] = [
     },
   },
   {
+    name: "tldr",
+    description: "Show a structured outline of what brane knows. Groups concepts into topics with one-line synopses and lists recent learnings.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        focus: { type: "string", description: "Focus on a topic area" },
+        limit: { type: "number", description: "Max items to load (default: 50)" },
+      },
+    },
+  },
+  {
     name: "lens_prompt_set",
     description: "Create or update a lens prompt (cognitive filter). Lens prompts shape how digest, storm, enhance, and ask process information. Use lens_prompt_on to activate after creating.",
     inputSchema: {
@@ -494,6 +505,7 @@ const TOOL_ROUTES: Record<string, string> = {
   loop:             "/calabi/loop",
   loop_list:        "/calabi/loop",
   rebuild:          "/calabi/rebuild",
+  tldr:             "/calabi/tldr",
   lens_prompt_set:  "/lens/prompt",
   lens_prompt_on:   "/lens/prompt",
   lens_prompt_off:  "/lens/prompt",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -178,6 +178,20 @@ const TOOLS: McpTool[] = [
     },
   },
   {
+    name: "storm",
+    description: "Divergent brainstorming over accumulated knowledge. Finds gaps, surfaces blind spots, proposes new connections, and suggests next actions. Generates new concepts, edges, and episodes. Supports multi-round deepening. Rate-limited.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        seed:    { type: "string", description: "Topic to seed brainstorming (optional — omit for broad brainstorm)" },
+        input:   { type: "string", description: "File path to brainstorm against" },
+        rounds:  { type: "number", description: "Iterative deepening rounds (default 1, max 5)" },
+        limit:   { type: "number", description: "Max context items per round (default 20)" },
+        dry_run: { type: "boolean", description: "Preview without writing to graph" },
+      },
+    },
+  },
+  {
     name: "ingest_sessions",
     description: "Passively ingest Claude Code session logs into episodic memory. Parses JSONL conversation logs to extract human↔assistant exchanges and store them as episodes. Tracks ingested sessions to avoid duplicates.",
     inputSchema: {
@@ -394,6 +408,7 @@ const TOOL_ROUTES: Record<string, string> = {
   ingest_sessions:  "/calabi/ingest-sessions",
   digest:           "/calabi/digest",
   ask:              "/calabi/ask",
+  storm:            "/calabi/storm",
 }
 
 //

--- a/try/active-lenses-spike.sh
+++ b/try/active-lenses-spike.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: Active Lenses (#63)
+#
+# Tests lens prompts as cognitive filters in MOCK mode.
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+brane() { (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" "$@"); }
+
+echo "=== Active Lenses Spike ==="
+echo ""
+
+# Setup
+brane init > /dev/null 2>&1
+
+echo "--- Running lens prompt tests ---"
+echo ""
+
+# Test 1: Create lens with prompt
+echo "# Test 1: Create lens prompt"
+RESULT=$(brane lens prompt security --set "Focus on authentication, authorization, encryption, attack surfaces" --json 2>/dev/null || true)
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.name==="security" ? 0 : 1)' 2>/dev/null; then
+  pass "create lens prompt"
+else
+  fail "create lens prompt" "$RESULT"
+fi
+
+# Test 2: Get lens prompt
+echo "# Test 2: Get lens prompt"
+RESULT2=$(brane lens prompt security --json 2>/dev/null || true)
+if echo "$RESULT2" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.prompt?.includes("authentication") ? 0 : 1)' 2>/dev/null; then
+  pass "get lens prompt returns stored text"
+else
+  fail "get lens prompt" "$RESULT2"
+fi
+
+# Test 3: Lens starts inactive
+echo "# Test 3: Starts inactive"
+if echo "$RESULT2" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.active===false ? 0 : 1)' 2>/dev/null; then
+  pass "lens starts inactive"
+else
+  fail "starts inactive" "$RESULT2"
+fi
+
+# Test 4: Activate lens
+echo "# Test 4: Activate lens"
+RESULT4=$(brane lens on security --json 2>/dev/null || true)
+if echo "$RESULT4" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.active===true ? 0 : 1)' 2>/dev/null; then
+  pass "activate lens"
+else
+  fail "activate" "$RESULT4"
+fi
+
+# Test 5: Verify active
+echo "# Test 5: Verify active"
+RESULT5=$(brane lens prompt security --json 2>/dev/null || true)
+if echo "$RESULT5" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.active===true ? 0 : 1)' 2>/dev/null; then
+  pass "lens shows as active"
+else
+  fail "verify active" "$RESULT5"
+fi
+
+# Test 6: Multiple lenses
+echo "# Test 6: Multiple active lenses"
+brane lens prompt performance --set "Focus on performance bottlenecks, latency, resource usage" > /dev/null 2>&1
+brane lens on performance > /dev/null 2>&1
+# Both should be active — test by trying to digest (prompt is auto-loaded)
+brane concept create --name "TestConcept" --type Entity > /dev/null 2>&1
+RESULT6=$(brane ask "test question" --json 2>/dev/null || true)
+if echo "$RESULT6" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" ? 0 : 1)' 2>/dev/null; then
+  pass "multiple active lenses don't break operations"
+else
+  fail "multiple lenses" "$RESULT6"
+fi
+
+# Test 7: Deactivate lens
+echo "# Test 7: Deactivate lens"
+RESULT7=$(brane lens off security --json 2>/dev/null || true)
+if echo "$RESULT7" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.active===false ? 0 : 1)' 2>/dev/null; then
+  pass "deactivate lens"
+else
+  fail "deactivate" "$RESULT7"
+fi
+
+# Test 8: Create lens with --prompt flag
+echo "# Test 8: Create lens namespace with prompt"
+RESULT8=$(brane lens create devops --prompt "Focus on CI/CD, deployment, infrastructure" --json 2>/dev/null || true)
+if echo "$RESULT8" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" ? 0 : 1)' 2>/dev/null; then
+  # Verify the prompt was saved
+  RESULT8B=$(brane lens prompt devops --json 2>/dev/null || true)
+  if echo "$RESULT8B" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.prompt?.includes("CI/CD") ? 0 : 1)' 2>/dev/null; then
+    pass "lens create --prompt saves prompt"
+  else
+    fail "create with prompt" "$RESULT8B"
+  fi
+else
+  fail "create lens" "$RESULT8"
+fi
+
+# Test 9: Activate nonexistent lens
+echo "# Test 9: Activate nonexistent"
+RESULT9=$(brane lens on nonexistent --json 2>/dev/null || true)
+if echo "$RESULT9" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="error" ? 0 : 1)' 2>/dev/null; then
+  pass "activate nonexistent returns error"
+else
+  fail "nonexistent" "$RESULT9"
+fi
+
+# Test 10: Pretty output
+echo "# Test 10: Pretty output"
+PRETTY=$(brane lens prompt security 2>/dev/null || true)
+if [ -n "$PRETTY" ] && echo "$PRETTY" | grep -qi -e "security" -e "authentication" -e "prompt"; then
+  pass "pretty output shows prompt info"
+else
+  fail "pretty output" "$PRETTY"
+fi
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/try/ask-spike.sh
+++ b/try/ask-spike.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: Ask (#60)
+#
+# Tests ask in MOCK mode first (no real LLM needed for basic flow),
+# then optionally with real LLM if BRANE_LLM_MOCK is not set.
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+brane() { (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" "$@"); }
+
+echo "=== Ask Spike ==="
+echo ""
+
+# Setup: init + populate with some knowledge
+brane init > /dev/null 2>&1
+
+echo "--- Populating knowledge ---"
+
+# Add some concepts
+brane concept create --name "AuthService" --type Entity > /dev/null 2>&1
+brane concept create --name "UserModel" --type Entity > /dev/null 2>&1
+brane concept create --name "LoginEndpoint" --type Entity > /dev/null 2>&1
+
+# Add edges
+brane edge create --from 1 --to 2 --rel "DEPENDS_ON" > /dev/null 2>&1
+brane edge create --from 3 --to 1 --rel "DEPENDS_ON" > /dev/null 2>&1
+
+# Add episodes
+brane memory remember --observation "AuthService handles JWT token validation" --context "code review" > /dev/null 2>&1
+brane memory remember --observation "UserModel stores hashed passwords in bcrypt format" --context "security audit" > /dev/null 2>&1
+
+echo "--- Running ask tests ---"
+echo ""
+
+# Test 1: Basic ask returns an answer
+echo "# Test 1: Basic ask"
+RESULT=$(brane ask "How does authentication work?" --json 2>/dev/null || true)
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.answer ? 0 : 1)' 2>/dev/null; then
+  pass "basic ask returns success with answer"
+else
+  fail "basic ask" "$RESULT"
+fi
+
+# Test 2: Answer has citations
+echo "# Test 2: Citations"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); const c=d.result?.citations; process.exit(c && Array.isArray(c.concept_ids) && Array.isArray(c.episode_ids) && Array.isArray(c.edge_ids) ? 0 : 1)' 2>/dev/null; then
+  pass "answer includes citations structure"
+else
+  fail "citations" "missing or malformed"
+fi
+
+# Test 3: Context loaded stats
+echo "# Test 3: Context stats"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); const c=d.result?.context_loaded; process.exit(c && typeof c.concepts==="number" && typeof c.episodes==="number" && typeof c.edges==="number" ? 0 : 1)' 2>/dev/null; then
+  pass "context_loaded stats present"
+else
+  fail "context stats" "missing or malformed"
+fi
+
+# Test 4: Missing question returns error
+echo "# Test 4: Missing question"
+RESULT4=$(brane ask "" --json 2>/dev/null || true)
+if echo "$RESULT4" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="error" ? 0 : 1)' 2>/dev/null; then
+  pass "missing question returns error"
+else
+  fail "missing question" "$RESULT4"
+fi
+
+# Test 5: Pretty output (non-JSON)
+echo "# Test 5: Pretty output"
+PRETTY=$(brane ask "What is AuthService?" 2>/dev/null || true)
+if [ -n "$PRETTY" ] && echo "$PRETTY" | grep -qi -e "auth" -e "concept" -e "Based on" -e "relevant" -e "don't have"; then
+  pass "pretty output contains answer text"
+else
+  fail "pretty output" "$PRETTY"
+fi
+
+# Test 6: Limit parameter
+echo "# Test 6: Limit parameter"
+RESULT6=$(brane ask "test" --limit 5 --json 2>/dev/null || true)
+if echo "$RESULT6" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" ? 0 : 1)' 2>/dev/null; then
+  pass "limit parameter accepted"
+else
+  fail "limit parameter" "$RESULT6"
+fi
+
+# Test 7: Empty knowledge graph
+echo "# Test 7: Empty graph"
+WORKSPACE2=$(mktemp -d)
+RESULT7=$( (cd "$WORKSPACE2" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" init > /dev/null 2>&1 && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" ask "anything" --json 2>/dev/null) || true)
+rm -rf "$WORKSPACE2"
+if echo "$RESULT7" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.answer?.includes("don") ? 0 : 1)' 2>/dev/null; then
+  pass "empty graph returns helpful message"
+else
+  fail "empty graph" "$RESULT7"
+fi
+
+# Test 8: After/before time filters
+echo "# Test 8: Time filters"
+RESULT8=$(brane ask "test" --after "2020-01-01" --before "2030-01-01" --json 2>/dev/null || true)
+if echo "$RESULT8" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" ? 0 : 1)' 2>/dev/null; then
+  pass "time filter parameters accepted"
+else
+  fail "time filters" "$RESULT8"
+fi
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/try/enhance-spike.sh
+++ b/try/enhance-spike.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: Enhance (#62)
+#
+# Tests convergent refinement in MOCK mode.
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+brane() { (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" "$@"); }
+
+echo "=== Enhance Spike ==="
+echo ""
+
+# Setup
+brane init > /dev/null 2>&1
+
+echo "--- Populating knowledge ---"
+brane concept create --name "AuthService" --type Entity > /dev/null 2>&1
+brane concept create --name "UserModel" --type Entity > /dev/null 2>&1
+brane concept create --name "LoginEndpoint" --type Entity > /dev/null 2>&1
+brane concept create --name "AuthenticationService" --type Entity > /dev/null 2>&1
+brane edge create --from 1 --to 2 --rel "DEPENDS_ON" > /dev/null 2>&1
+brane memory remember --observation "Auth uses JWT" --context "review" > /dev/null 2>&1
+
+echo "--- Running enhance tests ---"
+echo ""
+
+# Test 1: Basic enhance
+echo "# Test 1: Basic enhance"
+RESULT=$(brane enhance --json 2>/dev/null || true)
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.rounds_completed > 0 ? 0 : 1)' 2>/dev/null; then
+  pass "basic enhance returns success"
+else
+  fail "basic enhance" "$RESULT"
+fi
+
+# Test 2: Creates edges
+echo "# Test 2: Creates edges"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.total_edges > 0 ? 0 : 1)' 2>/dev/null; then
+  pass "enhance creates edges"
+else
+  fail "creates edges" "$RESULT"
+fi
+
+# Test 3: Adds observations
+echo "# Test 3: Observations"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.total_observations > 0 ? 0 : 1)' 2>/dev/null; then
+  pass "enhance adds observations"
+else
+  fail "observations" "$RESULT"
+fi
+
+# Test 4: Focused enhance
+echo "# Test 4: Focused enhance"
+RESULT4=$(brane enhance "authentication" --json 2>/dev/null || true)
+if echo "$RESULT4" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" ? 0 : 1)' 2>/dev/null; then
+  pass "focused enhance works"
+else
+  fail "focused enhance" "$RESULT4"
+fi
+
+# Test 5: Dry run doesn't modify graph
+echo "# Test 5: Dry run"
+EDGES_BEFORE=$(brane edge list --json 2>/dev/null | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); console.log(d.result?.items?.length ?? 0)' 2>/dev/null || echo "0")
+RESULT5=$(brane enhance --dry-run --json 2>/dev/null || true)
+EDGES_AFTER=$(brane edge list --json 2>/dev/null | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); console.log(d.result?.items?.length ?? 0)' 2>/dev/null || echo "0")
+if echo "$RESULT5" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.dry_run === true ? 0 : 1)' 2>/dev/null && [ "$EDGES_BEFORE" = "$EDGES_AFTER" ]; then
+  pass "dry run doesn't modify graph"
+else
+  fail "dry run" "edges before=$EDGES_BEFORE after=$EDGES_AFTER"
+fi
+
+# Test 6: Multi-round
+echo "# Test 6: Multi-round"
+RESULT6=$(brane enhance --rounds 2 --json 2>/dev/null || true)
+if echo "$RESULT6" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.rounds_completed === 2 ? 0 : 1)' 2>/dev/null; then
+  pass "multi-round enhance works"
+else
+  fail "multi-round" "$RESULT6"
+fi
+
+# Test 7: Pretty output
+echo "# Test 7: Pretty output"
+PRETTY=$(brane enhance 2>/dev/null || true)
+if [ -n "$PRETTY" ] && echo "$PRETTY" | grep -qi -e "merge" -e "edge" -e "observation" -e "round" -e "refine"; then
+  pass "pretty output contains expected text"
+else
+  fail "pretty output" "$PRETTY"
+fi
+
+# Test 8: Empty graph
+echo "# Test 8: Empty graph"
+WORKSPACE2=$(mktemp -d)
+RESULT8=$( (cd "$WORKSPACE2" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" init > /dev/null 2>&1 && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" enhance --json 2>/dev/null) || true)
+rm -rf "$WORKSPACE2"
+if echo "$RESULT8" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.rounds_completed === 0 ? 0 : 1)' 2>/dev/null; then
+  pass "empty graph returns 0 rounds"
+else
+  fail "empty graph" "$RESULT8"
+fi
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/try/loop-spike.sh
+++ b/try/loop-spike.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: Loop (#64)
+#
+# Tests autonomous research loop in MOCK mode.
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+brane() { (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" "$@"); }
+
+echo "=== Loop Spike ==="
+echo ""
+
+# Setup
+brane init > /dev/null 2>&1
+
+echo "--- Running loop tests ---"
+echo ""
+
+# Test 1: Basic loop runs and converges
+echo "# Test 1: Basic loop"
+RESULT=$(brane loop run "understand JWT tokens" --rounds 3 --json 2>/dev/null || true)
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.id ? 0 : 1)' 2>/dev/null; then
+  pass "basic loop returns success with ID"
+else
+  fail "basic loop" "$RESULT"
+fi
+
+# Test 2: Loop has rounds
+echo "# Test 2: Rounds executed"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.rounds_completed > 0 ? 0 : 1)' 2>/dev/null; then
+  pass "loop executed rounds"
+else
+  fail "rounds" "$RESULT"
+fi
+
+# Test 3: Converges (mock converges after round 2)
+echo "# Test 3: Convergence"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.status==="converged" || d.result?.status==="max_rounds" ? 0 : 1)' 2>/dev/null; then
+  pass "loop reached terminal state"
+else
+  fail "convergence" "$RESULT"
+fi
+
+# Test 4: Rounds have expected structure
+echo "# Test 4: Round structure"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); const r=d.result?.rounds?.[0]; process.exit(r && typeof r.assessment==="string" && Array.isArray(r.gaps) && Array.isArray(r.queries_searched) ? 0 : 1)' 2>/dev/null; then
+  pass "rounds have expected fields"
+else
+  fail "round structure" "$RESULT"
+fi
+
+# Test 5: Loop list
+echo "# Test 5: Loop list"
+RESULT5=$(brane loop list --json 2>/dev/null || true)
+if echo "$RESULT5" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.loops?.length > 0 ? 0 : 1)' 2>/dev/null; then
+  pass "loop list shows completed loop"
+else
+  fail "loop list" "$RESULT5"
+fi
+
+# Test 6: Dry run
+echo "# Test 6: Dry run"
+RESULT6=$(brane loop run "test goal" --rounds 2 --dry-run --json 2>/dev/null || true)
+if echo "$RESULT6" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.dry_run===true ? 0 : 1)' 2>/dev/null; then
+  pass "dry run mode works"
+else
+  fail "dry run" "$RESULT6"
+fi
+
+# Test 7: Resume
+echo "# Test 7: Resume (creates new loop, pauses not applicable in mock)"
+LOOP_ID=$(echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); console.log(d.result?.id??"")' 2>/dev/null || echo "")
+if [ -n "$LOOP_ID" ]; then
+  RESULT7=$(brane loop run --resume "$LOOP_ID" --rounds 5 --json 2>/dev/null || true)
+  if echo "$RESULT7" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" ? 0 : 1)' 2>/dev/null; then
+    pass "resume existing loop"
+  else
+    fail "resume" "$RESULT7"
+  fi
+else
+  fail "resume" "no loop ID from previous run"
+fi
+
+# Test 8: Pretty output
+echo "# Test 8: Pretty output"
+PRETTY=$(brane loop run "architecture patterns" --rounds 2 2>/dev/null || true)
+if [ -n "$PRETTY" ] && echo "$PRETTY" | grep -qi -e "round" -e "loop" -e "status" -e "converging"; then
+  pass "pretty output contains expected text"
+else
+  fail "pretty output" "$PRETTY"
+fi
+
+# Test 9: Search history prevents duplicates
+echo "# Test 9: Search history"
+RESULT9=$(brane loop run "same topic again" --rounds 3 --json 2>/dev/null || true)
+# In mock mode, queries are deterministic, so round 2 should have fewer/no queries since round 1 used them
+if echo "$RESULT9" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" ? 0 : 1)' 2>/dev/null; then
+  pass "search history tracked"
+else
+  fail "search history" "$RESULT9"
+fi
+
+# Test 10: Episodes created as journal
+echo "# Test 10: Journal episodes"
+EPS=$(brane memory list --json 2>/dev/null || true)
+if echo "$EPS" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); const eps=d.result?.episodes??[]; process.exit(eps.some(e=>e.context?.includes("loop:")) ? 0 : 1)' 2>/dev/null; then
+  pass "loop creates journal episodes"
+else
+  fail "journal episodes" "$EPS"
+fi
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/try/rebuild-spike.sh
+++ b/try/rebuild-spike.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: Rebuild (#65)
+#
+# Tests re-extraction in MOCK mode.
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+brane() { (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" "$@"); }
+
+echo "=== Rebuild Spike ==="
+echo ""
+
+# Setup: init and digest some files
+brane init > /dev/null 2>&1
+
+echo "--- Creating test files and digesting ---"
+mkdir -p "$WORKSPACE/docs"
+echo "Authentication uses JWT tokens with refresh rotation." > "$WORKSPACE/docs/auth.md"
+echo "Rate limiting is enforced at the API gateway level." > "$WORKSPACE/docs/rate-limit.md"
+
+brane digest "$WORKSPACE/docs/auth.md" > /dev/null 2>&1
+brane digest "$WORKSPACE/docs/rate-limit.md" > /dev/null 2>&1
+
+echo "--- Running rebuild tests ---"
+echo ""
+
+# Test 1: Dry run shows sources
+echo "# Test 1: Dry run"
+RESULT=$(brane rebuild --dry-run --json 2>/dev/null || true)
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.sources_total >= 2 ? 0 : 1)' 2>/dev/null; then
+  pass "dry run shows digested sources"
+else
+  fail "dry run" "$RESULT"
+fi
+
+# Test 2: Dry run is actually dry
+echo "# Test 2: Dry run is dry"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.dry_run===true && d.result?.sources_rebuilt===0 ? 0 : 1)' 2>/dev/null; then
+  pass "dry run doesn't rebuild"
+else
+  fail "dry run is dry" "$RESULT"
+fi
+
+# Test 3: Full rebuild
+echo "# Test 3: Full rebuild"
+RESULT3=$(brane rebuild --json 2>/dev/null || true)
+if echo "$RESULT3" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.sources_rebuilt >= 2 ? 0 : 1)' 2>/dev/null; then
+  pass "rebuild processes all sources"
+else
+  fail "full rebuild" "$RESULT3"
+fi
+
+# Test 4: Result details
+echo "# Test 4: Result details"
+if echo "$RESULT3" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); const det=d.result?.details??[]; process.exit(det.length >= 2 && det.every(d=>d.label && d.status) ? 0 : 1)' 2>/dev/null; then
+  pass "details include label and status per source"
+else
+  fail "details" "$RESULT3"
+fi
+
+# Test 5: Empty rebuild (nothing to rebuild after just rebuilding)
+echo "# Test 5: No sources"
+WORKSPACE2=$(mktemp -d)
+RESULT5=$( (cd "$WORKSPACE2" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" init > /dev/null 2>&1 && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" rebuild --json 2>/dev/null) || true)
+rm -rf "$WORKSPACE2"
+if echo "$RESULT5" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.sources_total===0 ? 0 : 1)' 2>/dev/null; then
+  pass "empty graph rebuild returns 0 sources"
+else
+  fail "empty rebuild" "$RESULT5"
+fi
+
+# Test 6: Pretty output
+echo "# Test 6: Pretty output"
+# Re-digest so there's something to rebuild
+brane digest "$WORKSPACE/docs/auth.md" > /dev/null 2>&1
+PRETTY=$(brane rebuild 2>/dev/null || true)
+if [ -n "$PRETTY" ] && echo "$PRETTY" | grep -qi -e "rebuilt" -e "sources" -e "skip"; then
+  pass "pretty output shows rebuild info"
+else
+  fail "pretty output" "$PRETTY"
+fi
+
+# Test 7: Lens override
+echo "# Test 7: Lens override"
+brane digest "$WORKSPACE/docs/rate-limit.md" > /dev/null 2>&1
+RESULT7=$(brane rebuild --lens "Focus on security" --json 2>/dev/null || true)
+if echo "$RESULT7" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" ? 0 : 1)' 2>/dev/null; then
+  pass "lens override accepted"
+else
+  fail "lens override" "$RESULT7"
+fi
+
+# Test 8: Stdin sources are skipped
+echo "# Test 8: Stdin skipped"
+echo "Some stdin content" | brane digest - > /dev/null 2>&1
+RESULT8=$(brane rebuild --json 2>/dev/null || true)
+HAS_STDIN=$(echo "$RESULT8" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); const det=d.result?.details??[]; const stdin=det.find(d=>d.label==="stdin"); console.log(stdin?.status??"none")' 2>/dev/null || echo "none")
+if [ "$HAS_STDIN" = "skipped" ] || [ "$HAS_STDIN" = "none" ]; then
+  pass "stdin sources handled gracefully"
+else
+  fail "stdin skipped" "$HAS_STDIN"
+fi
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/try/storm-spike.sh
+++ b/try/storm-spike.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: Storm (#61)
+#
+# Tests brainstorming in MOCK mode.
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+brane() { (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" "$@"); }
+
+echo "=== Storm Spike ==="
+echo ""
+
+# Setup
+brane init > /dev/null 2>&1
+
+echo "--- Populating knowledge ---"
+brane concept create --name "AuthService" --type Entity > /dev/null 2>&1
+brane concept create --name "UserModel" --type Entity > /dev/null 2>&1
+brane edge create --from 1 --to 2 --rel "DEPENDS_ON" > /dev/null 2>&1
+brane memory remember --observation "Auth uses JWT tokens" --context "review" > /dev/null 2>&1
+
+echo "--- Running storm tests ---"
+echo ""
+
+# Test 1: Basic unseeded storm
+echo "# Test 1: Basic storm"
+RESULT=$(brane storm --json 2>/dev/null || true)
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" && d.result?.rounds_completed > 0 ? 0 : 1)' 2>/dev/null; then
+  pass "basic storm returns success"
+else
+  fail "basic storm" "$RESULT"
+fi
+
+# Test 2: Storm creates knowledge
+echo "# Test 2: Creates knowledge"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); const r=d.result; process.exit(r?.total_concepts > 0 || r?.total_episodes > 0 ? 0 : 1)' 2>/dev/null; then
+  pass "storm creates concepts or episodes"
+else
+  fail "creates knowledge" "$RESULT"
+fi
+
+# Test 3: Storm returns suggestions
+echo "# Test 3: Suggestions"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(Array.isArray(d.result?.suggestions) && d.result.suggestions.length > 0 ? 0 : 1)' 2>/dev/null; then
+  pass "storm returns suggestions"
+else
+  fail "suggestions" "$RESULT"
+fi
+
+# Test 4: Seeded storm
+echo "# Test 4: Seeded storm"
+RESULT4=$(brane storm "security" --json 2>/dev/null || true)
+if echo "$RESULT4" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" ? 0 : 1)' 2>/dev/null; then
+  pass "seeded storm works"
+else
+  fail "seeded storm" "$RESULT4"
+fi
+
+# Test 5: Dry run
+echo "# Test 5: Dry run"
+# Count concepts before
+BEFORE=$(brane concept list --json 2>/dev/null | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); console.log(d.result?.items?.length ?? 0)' 2>/dev/null || echo "0")
+RESULT5=$(brane storm "testing" --dry-run --json 2>/dev/null || true)
+AFTER=$(brane concept list --json 2>/dev/null | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); console.log(d.result?.items?.length ?? 0)' 2>/dev/null || echo "0")
+if echo "$RESULT5" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.dry_run === true ? 0 : 1)' 2>/dev/null && [ "$BEFORE" = "$AFTER" ]; then
+  pass "dry run doesn't write to graph"
+else
+  fail "dry run" "before=$BEFORE after=$AFTER result=$RESULT5"
+fi
+
+# Test 6: Multi-round
+echo "# Test 6: Multi-round"
+RESULT6=$(brane storm "architecture" --rounds 2 --json 2>/dev/null || true)
+if echo "$RESULT6" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.result?.rounds_completed === 2 && d.result?.rounds?.length === 2 ? 0 : 1)' 2>/dev/null; then
+  pass "multi-round storm completes 2 rounds"
+else
+  fail "multi-round" "$RESULT6"
+fi
+
+# Test 7: Pretty output
+echo "# Test 7: Pretty output"
+PRETTY=$(brane storm "testing" 2>/dev/null || true)
+if [ -n "$PRETTY" ] && echo "$PRETTY" | grep -qi -e "concept" -e "episode" -e "suggestion" -e "round"; then
+  pass "pretty output contains expected text"
+else
+  fail "pretty output" "$PRETTY"
+fi
+
+# Test 8: Input file
+echo "# Test 8: Input file"
+echo "This is a test document about microservices architecture and API design." > "$WORKSPACE/test-input.md"
+RESULT8=$(brane storm --input test-input.md --json 2>/dev/null || true)
+if echo "$RESULT8" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="success" ? 0 : 1)' 2>/dev/null; then
+  pass "input file brainstorming works"
+else
+  fail "input file" "$RESULT8"
+fi
+
+# Test 9: Missing input file
+echo "# Test 9: Missing input file"
+RESULT9=$(brane storm --input nonexistent.md --json 2>/dev/null || true)
+if echo "$RESULT9" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); process.exit(d.status==="error" ? 0 : 1)' 2>/dev/null; then
+  pass "missing input file returns error"
+else
+  fail "missing input" "$RESULT9"
+fi
+
+# Test 10: Suggestion kinds
+echo "# Test 10: Suggestion kinds"
+if echo "$RESULT" | bun -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); const kinds=d.result?.suggestions?.map(s=>s.kind)??[]; process.exit(kinds.includes("question") || kinds.includes("source") || kinds.includes("lens") ? 0 : 1)' 2>/dev/null; then
+  pass "suggestions have valid kinds"
+else
+  fail "suggestion kinds" "$RESULT"
+fi
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/try/tldr-spike.sh
+++ b/try/tldr-spike.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Whitebox spike: TLDR (#66)
+#
+# Tests knowledge outline in MOCK mode.
+#
+set -euo pipefail
+
+BRANE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BRANE_ROOT"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ❌ $1: $2"; }
+
+WORKSPACE=$(mktemp -d)
+trap "rm -rf $WORKSPACE" EXIT
+
+brane() { (cd "$WORKSPACE" && BRANE_EMBED_MOCK=1 BRANE_LLM_MOCK=1 bun run "$BRANE_ROOT/src/cli.ts" "$@"); }
+
+echo "=== TLDR Spike ==="
+echo ""
+
+# Setup
+brane init > /dev/null 2>&1
+
+echo "--- 1. Empty graph ---"
+OUT=$(brane tldr --json 2>/dev/null)
+STATUS=$(echo "$OUT" | jq -r '.status')
+TOPICS=$(echo "$OUT" | jq -r '.result.topics | length')
+if [ "$STATUS" = "success" ] && [ "$TOPICS" = "0" ]; then
+  pass "empty graph returns success with 0 topics"
+else
+  fail "empty graph" "status=$STATUS topics=$TOPICS"
+fi
+
+echo "--- 2. Populate graph ---"
+# Add some concepts
+brane concept create --name "AuthService" --type "Entity" > /dev/null 2>&1
+brane concept create --name "UserModel" --type "Entity" > /dev/null 2>&1
+brane concept create --name "OAuth2" --type "Pattern" > /dev/null 2>&1
+brane concept create --name "JWT" --type "Pattern" > /dev/null 2>&1
+brane edge create --from "AuthService" --to "UserModel" --rel "DEPENDS_ON" > /dev/null 2>&1
+brane edge create --from "AuthService" --to "OAuth2" --rel "IMPLEMENTS" > /dev/null 2>&1
+
+echo "--- 3. TLDR with populated graph (JSON) ---"
+OUT=$(brane tldr --json 2>/dev/null)
+STATUS=$(echo "$OUT" | jq -r '.status')
+TOPICS=$(echo "$OUT" | jq -r '.result.topics | length')
+CONCEPTS=$(echo "$OUT" | jq -r '.result.stats.concepts')
+EDGES=$(echo "$OUT" | jq -r '.result.stats.edges')
+if [ "$STATUS" = "success" ] && [ "$TOPICS" -gt 0 ]; then
+  pass "populated graph returns topics"
+else
+  fail "populated graph" "status=$STATUS topics=$TOPICS"
+fi
+
+if [ "$CONCEPTS" -gt 0 ] && [ "$EDGES" -gt 0 ]; then
+  pass "stats include concepts=$CONCEPTS edges=$EDGES"
+else
+  fail "stats" "concepts=$CONCEPTS edges=$EDGES"
+fi
+
+echo "--- 4. TLDR with focus ---"
+OUT=$(brane tldr --focus "auth" --json 2>/dev/null)
+STATUS=$(echo "$OUT" | jq -r '.status')
+if [ "$STATUS" = "success" ]; then
+  pass "focus mode returns success"
+else
+  fail "focus mode" "status=$STATUS"
+fi
+
+echo "--- 5. TLDR with limit ---"
+OUT=$(brane tldr --limit 2 --json 2>/dev/null)
+STATUS=$(echo "$OUT" | jq -r '.status')
+if [ "$STATUS" = "success" ]; then
+  pass "limit mode returns success"
+else
+  fail "limit mode" "status=$STATUS"
+fi
+
+echo "--- 6. TLDR text output ---"
+OUT=$(brane tldr 2>/dev/null)
+if echo "$OUT" | grep -q "##"; then
+  pass "text output has topic headings"
+else
+  fail "text output" "no ## headings found"
+fi
+
+if echo "$OUT" | grep -q "concepts"; then
+  pass "text output has stats line"
+else
+  fail "text output stats" "no stats line found"
+fi
+
+echo "--- 7. Topics have items ---"
+OUT=$(brane tldr --json 2>/dev/null)
+FIRST_ITEMS=$(echo "$OUT" | jq -r '.result.topics[0].items | length')
+if [ "$FIRST_ITEMS" -gt 0 ]; then
+  pass "first topic has $FIRST_ITEMS items"
+else
+  fail "topic items" "first topic has 0 items"
+fi
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- **`brane ask <question>`** — vector-searches concepts + episodes, enriches with graph neighbors, synthesizes answer via LLM with citations
- Handler at `/calabi/ask`, CLI command, MCP tool registered
- Mock mode for testing, rate-limited LLM calls, empty-graph early return with helpful message
- Spike test: 8/8, tc suite: 349/0, examples: 16/16

## Test plan
- [x] Spike test (`try/ask-spike.sh`) — 8 tests covering basic ask, citations, context stats, missing question, pretty output, limit param, empty graph, time filters
- [x] Full tc suite passes (349/0)
- [x] All examples pass (16/16)
- [ ] Gemini antagonistic review (quota exhausted, deferred)
- [ ] Real LLM integration test (manual)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)