### PR TITLE
Fix QA issues #93-#98

### DIFF
--- a/demos/qa/03-memory-agent.sh
+++ b/demos/qa/03-memory-agent.sh
@@ -273,7 +273,7 @@ echo ""
 echo "── 10: Verify ──"
 OUT=$(BJ verify)
 STATUS=$(echo "$OUT" | jq -r '.status' 2>/dev/null)
-VALID=$(echo "$OUT" | jq -r '.result.valid // "null"' 2>/dev/null)
+VALID=$(echo "$OUT" | jq -r '.result.passed // "null"' 2>/dev/null)
 if [ "$STATUS" = "success" ]; then
   pass "verify: valid=$VALID"
 else

--- a/demos/qa/ISSUES.md
+++ b/demos/qa/ISSUES.md
@@ -10,57 +10,38 @@ Issues discovered by Gemini-reviewed QA demos (2026-03-28).
 - **Impact**: `brane annotation create` and `brane annotation list --concept` were broken
 - **Fix**: Changed `concept_id` to `target` in CLI params
 
-## Issues to Address
+## Issues Fixed (GitHub #93–#98)
 
-### 1. CLI error responses are not always JSON
-- **Severity**: Medium
-- **What**: Some CLI commands (edge create with non-existent concept, graph neighbors with non-existent concept) exit non-zero with plain text errors instead of structured JSON error envelopes
-- **Where**: `src/cli/commands/edge.ts`, `src/cli/commands/graph.ts`
-- **Impact**: MCP and programmatic consumers can't reliably parse errors
-- **Fix**: Ensure all CLI commands return JSON error envelopes when `--json` is specified
+### #93 — CLI error responses are not always JSON ✅
+- **Where**: `src/cli/commands/edge.ts`, `graph.ts`, `memory.ts`, `loop.ts`
+- **Fix**: Added `cli_error()` helper, all CLI validation errors now return JSON envelopes
 
-### 2. No CLI for lens prompt list/delete
-- **Severity**: Low
-- **What**: `lens prompt set`, `lens on`, `lens off`, `lens prompt <name>` (get) exist, but there's no way to list all prompts or delete a prompt from the CLI
+### #94 — No CLI for lens prompt list/delete ✅
 - **Where**: `src/cli/commands/lens.ts`
-- **Impact**: Users can only manage prompts through MCP or the REPL
-- **Fix**: Add `lens prompt list` and `lens prompt delete <name>` subcommands
+- **Fix**: Added `lens prompts` subcommand and `--delete` flag on `lens prompt`
 
-### 3. Mock embeddings don't test semantic similarity
-- **Severity**: Low (test-only)
-- **What**: Mock embeddings return deterministic vectors that make ALL concepts match search queries equally. Recall/search tests can't verify ranking quality.
-- **Where**: `src/lib/embed/mock.ts`
-- **Impact**: Search bugs won't be caught by mock-mode tests
-- **Mitigations**: Live E2E tests with real embeddings (separate suite)
-
-### 4. Concept create is a silent upsert
-- **Severity**: Informational
-- **What**: Creating a concept with a name that already exists returns success with the existing ID (CozoDB put semantics). No indication that it was an update, not a create.
+### #95 — Concept create is a silent upsert ✅
 - **Where**: `src/handlers/mind/concepts/create.ts`
-- **Impact**: Users may not realize they're overwriting an existing concept
-- **Possible fix**: Return `created: false, existing: true` in the result when upserting
+- **Fix**: Exact name match check returns `matched_existing: true, match_type: "exact"`
 
-### 5. Cascading deletes not verified
-- **Severity**: Medium
-- **What**: Deleting a concept doesn't seem to clean up associated edges, annotations, or provenance links
+### #96 — Cascading deletes not verified ✅
 - **Where**: `src/handlers/mind/concepts/delete.ts`
-- **Impact**: Orphaned edges pointing to deleted concepts could cause graph corruption
-- **Fix**: Either cascade deletes or error when deleting a concept with edges
+- **Fix**: Cascade deletes edges, annotations, provenance; returns counts in `cascade` object
 
-### 6. No update/modify operations tested
-- **Severity**: Low
-- **What**: Concept update and edge update exist as handlers but aren't exercised by any demo
-- **Where**: Demo coverage gap
-- **Fix**: Add update tests to demo 03
+### #97 — graph summary vs status use different field names ✅
+- **Where**: `src/handlers/graph/summary.ts`
+- **Fix**: Added flat `total_concepts`/`total_edges` aliases alongside structured fields
 
-### 7. graph summary vs status use different field names
-- **Severity**: Informational
-- **What**: `status --json` uses `total_concepts`/`total_edges`, `graph summary --json` uses `concepts.total`/`edges.total`
-- **Impact**: Inconsistency for consumers; easy to use wrong field name
-- **Fix**: Normalize field names or document the difference
+### #98 — verify result doesn't include `valid` field ✅
+- **Where**: QA demo used wrong field name (`.result.valid` → `.result.passed`)
+- **Fix**: Updated demo; handler already returns `passed: boolean` correctly
 
-### 8. verify result doesn't include `valid` field
-- **Severity**: Low
-- **What**: `verify --json` returns success but `.result.valid` is undefined (null). The verify result doesn't explicitly include a `valid: true/false` field.
-- **Where**: `src/handlers/mind/verify.ts`
-- **Impact**: Programmatic consumers can't distinguish "verified OK" from "nothing to verify"
+## Remaining (Won't Fix / Tracked Separately)
+
+### Mock embeddings don't test semantic similarity
+- **Severity**: Low (test-only)
+- **Mitigation**: Live E2E tests with real embeddings (separate suite)
+
+### No update/modify operations tested
+- **Severity**: Low (demo coverage gap)
+- **Mitigation**: Future demo expansion

--- a/src/cli/commands/edge.ts
+++ b/src/cli/commands/edge.ts
@@ -4,7 +4,7 @@
 
 import { defineCommand } from "citty"
 import { sys } from "../../index.ts"
-import { output } from "../output.ts"
+import { output, cli_error } from "../output.ts"
 import { resolve_concept_ref } from "../resolve.ts"
 
 export const edge = defineCommand({
@@ -25,14 +25,12 @@ export const edge = defineCommand({
       async run({ args }) {
         const source = await resolve_concept_ref(args.from)
         if (source === null) {
-          console.error(`error: concept not found: ${args.from}`)
-          process.exit(1)
+          cli_error("from", "not_found", `concept not found: ${args.from}`, { json: args.json })
         }
 
         const target = await resolve_concept_ref(args.to)
         if (target === null) {
-          console.error(`error: concept not found: ${args.to}`)
-          process.exit(1)
+          cli_error("to", "not_found", `concept not found: ${args.to}`, { json: args.json })
         }
 
         const params: any = {

--- a/src/cli/commands/graph.ts
+++ b/src/cli/commands/graph.ts
@@ -4,7 +4,7 @@
 
 import { defineCommand } from "citty"
 import { sys } from "../../index.ts"
-import { output } from "../output.ts"
+import { output, cli_error } from "../output.ts"
 import { resolve_concept_ref } from "../resolve.ts"
 
 export const graph = defineCommand({
@@ -102,16 +102,14 @@ export const graph = defineCommand({
         if (args.from) {
           const source = await resolve_concept_ref(args.from)
           if (source === null) {
-            console.error(`error: concept not found: ${args.from}`)
-            process.exit(1)
+            cli_error("from", "not_found", `concept not found: ${args.from}`, { json: args.json })
           }
           params.source = source
         }
         if (args.to) {
           const target = await resolve_concept_ref(args.to)
           if (target === null) {
-            console.error(`error: concept not found: ${args.to}`)
-            process.exit(1)
+            cli_error("to", "not_found", `concept not found: ${args.to}`, { json: args.json })
           }
           params.target = target
         }
@@ -155,8 +153,7 @@ export const graph = defineCommand({
       async run({ args }) {
         const id = await resolve_concept_ref(args.id)
         if (id === null) {
-          console.error(`error: concept not found: ${args.id}`)
-          process.exit(1)
+          cli_error("id", "not_found", `concept not found: ${args.id}`, { json: args.json })
         }
 
         const result = await sys.call("/graph/neighbors", { id })
@@ -217,8 +214,7 @@ export const graph = defineCommand({
         if (args.center) {
           const center = await resolve_concept_ref(args.center)
           if (center === null) {
-            console.error(`error: concept not found: ${args.center}`)
-            process.exit(1)
+            cli_error("center", "not_found", `concept not found: ${args.center}`, { json: args.json })
           }
           params.center = center
         }

--- a/src/cli/commands/lens.ts
+++ b/src/cli/commands/lens.ts
@@ -340,15 +340,25 @@ export const lens = defineCommand({
     }),
 
     prompt: defineCommand({
-      meta: { name: "prompt", description: "Set or view a lens prompt" },
+      meta: { name: "prompt", description: "Set, view, or delete a lens prompt" },
       args: {
         name: { type: "positional", description: "Lens prompt name", required: true },
         set: { type: "string", alias: "s", description: "Set the prompt text" },
+        delete: { type: "boolean", description: "Delete the prompt" },
         description: { type: "string", alias: "d", description: "Lens description" },
         json: { type: "boolean", alias: "j", description: "Output as JSON" },
       },
       async run({ args }) {
-        if (args.set) {
+        if (args.delete) {
+          const result = await sys.call("/lens/prompt", { action: "delete", name: args.name })
+          if (args.json) {
+            output(result, { json: true })
+          } else if (result.status === "success") {
+            console.log(`deleted lens prompt: ${args.name}`)
+          } else {
+            output(result, {})
+          }
+        } else if (args.set) {
           const result = await sys.call("/lens/prompt", {
             action: "set",
             name: args.name,
@@ -375,6 +385,32 @@ export const lens = defineCommand({
           } else {
             output(result, {})
           }
+        }
+      },
+    }),
+
+    prompts: defineCommand({
+      meta: { name: "prompts", description: "List all lens prompts" },
+      args: {
+        json: { type: "boolean", alias: "j", description: "Output as JSON" },
+      },
+      async run({ args }) {
+        const result = await sys.call("/lens/prompt", { action: "list" })
+        if (args.json) {
+          output(result, { json: true })
+        } else if (result.status === "success" && result.result) {
+          const r = result.result as { prompts: Array<{ name: string; prompt: string; active: boolean; description: string }> }
+          if (r.prompts.length === 0) {
+            console.log("(no lens prompts)")
+          } else {
+            for (const p of r.prompts) {
+              const marker = p.active ? "* " : "  "
+              const desc = p.description ? ` — ${p.description}` : ""
+              console.log(`${marker}${p.name}${desc}`)
+            }
+          }
+        } else {
+          output(result, {})
         }
       },
     }),

--- a/src/cli/commands/loop.ts
+++ b/src/cli/commands/loop.ts
@@ -6,7 +6,7 @@
 
 import { defineCommand } from "citty"
 import { sys } from "../../index.ts"
-import { output } from "../output.ts"
+import { output, cli_error } from "../output.ts"
 
 const loopRun = defineCommand({
   meta: {
@@ -30,8 +30,7 @@ const loopRun = defineCommand({
     if (args["dry-run"]) params.dry_run = true
 
     if (!args.goal && !args.resume) {
-      console.error("error: goal is required (or --resume <id>)")
-      process.exit(1)
+      cli_error("goal", "required", "goal is required (or --resume <id>)", { json: args.json })
     }
 
     const result = await sys.call("/calabi/loop", params)

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -5,7 +5,7 @@
 import { defineCommand } from "citty"
 import { sys } from "../../index.ts"
 import { auto_tag } from "../../lib/auto-tag.ts"
-import { output } from "../output.ts"
+import { output, cli_error } from "../output.ts"
 
 const remember = defineCommand({
   meta: {
@@ -108,8 +108,7 @@ const forget = defineCommand({
   async run({ args }) {
     const raw_id = String(args.id)
     if (!/^\d+$/.test(raw_id)) {
-      console.error("error: id must be a positive integer")
-      process.exit(1)
+      cli_error("id", "invalid", "id must be a positive integer", { json: args.json })
     }
     const id = parseInt(raw_id, 10)
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -3,6 +3,7 @@
 //
 
 import type { Result } from "../lib/types.ts"
+import { error as make_error } from "../lib/result.ts"
 
 export interface OutputOptions {
   json?: boolean
@@ -210,6 +211,15 @@ function format_object(data: any): void {
       console.log(`${capitalize(key)}: ${value}`)
     }
   }
+}
+
+//
+// CLI error helper — creates a proper Result error and outputs it
+//
+export function cli_error(field: string, code: string, message: string, options: OutputOptions = {}): never {
+  const result = make_error({ [field]: [{ code, message }] })
+  output(result, options)
+  process.exit(1) // fallback — output() already exits on error
 }
 
 function capitalize(s: string): string {

--- a/src/handlers/graph/summary.ts
+++ b/src/handlers/graph/summary.ts
@@ -7,6 +7,8 @@ import { success, error } from "../../lib/result.ts"
 import { open_mind, is_mind_error } from "../../lib/mind.ts"
 
 interface SummaryResult {
+  total_concepts: number
+  total_edges: number
   concepts: {
     total: number
     by_type: Record<string, number>
@@ -66,6 +68,8 @@ export async function handler(_params: Params, _emit?: Emit): Promise<Result<Sum
     db.close()
 
     return success({
+      total_concepts: concept_total,
+      total_edges: edge_total,
       concepts: {
         total: concept_total,
         by_type

--- a/src/handlers/mind/concepts/create.ts
+++ b/src/handlers/mind/concepts/create.ts
@@ -89,6 +89,21 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Conce
       }
     }
 
+    // Check for exact name match (CozoDB put is an upsert — detect and report)
+    const exact = await db.run(`?[id, name, type, agent_id] := *concepts[id, name, type, _, agent_id], name = '${p.name.replace(/'/g, "''")}'`)
+    if (exact.rows.length > 0) {
+      const row = exact.rows[0]
+      db.close()
+      return success({
+        id:               row[0] as number,
+        name:             row[1] as string,
+        type:             row[2] as string,
+        agent_id:         (row[3] as string) || null,
+        matched_existing: true,
+        match_type:       "exact",
+      })
+    }
+
     // Get next ID
     const id = await get_next_concept_id(db)
 

--- a/src/handlers/mind/concepts/delete.ts
+++ b/src/handlers/mind/concepts/delete.ts
@@ -12,6 +12,11 @@ interface DeleteParams {
 
 interface DeleteResult {
   deleted: boolean
+  cascade: {
+    edges_removed: number
+    annotations_removed: number
+    provenance_removed: number
+  }
 }
 
 export async function handler(params: Params, emit?: Emit): Promise<Result<DeleteResult>> {
@@ -59,7 +64,46 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Delet
       })
     }
 
-    // Delete the concept (need all fields for :rm)
+    // Cascade: remove edges where this concept is source or target
+    let edges_removed = 0
+    try {
+      const edge_count = await db.run(`?[count(id)] := *edges[id, source, target, _, _, _], source = ${p.id} or target = ${p.id}`)
+      edges_removed = (edge_count.rows[0]?.[0] as number) ?? 0
+      if (edges_removed > 0) {
+        await db.run(`
+          ?[id, source, target, relation, weight, agent_id] := *edges[id, source, target, relation, weight, agent_id], source = ${p.id} or target = ${p.id}
+          :rm edges { id, source, target, relation, weight, agent_id }
+        `)
+      }
+    } catch { /* edges relation may not exist */ }
+
+    // Cascade: remove annotations targeting this concept
+    let annotations_removed = 0
+    try {
+      const ann_count = await db.run(`?[count(id)] := *annotations[id, target, _, _, _, _], target = ${p.id}`)
+      annotations_removed = (ann_count.rows[0]?.[0] as number) ?? 0
+      if (annotations_removed > 0) {
+        await db.run(`
+          ?[id, target, text, type, authority, created_at] := *annotations[id, target, text, type, authority, created_at], target = ${p.id}
+          :rm annotations { id, target, text, type, authority, created_at }
+        `)
+      }
+    } catch { /* annotations relation may not exist */ }
+
+    // Cascade: remove provenance links for this concept
+    let provenance_removed = 0
+    try {
+      const prov_count = await db.run(`?[count(concept_id)] := *provenance[concept_id, file_url], concept_id = ${p.id}`)
+      provenance_removed = (prov_count.rows[0]?.[0] as number) ?? 0
+      if (provenance_removed > 0) {
+        await db.run(`
+          ?[concept_id, file_url] := *provenance[concept_id, file_url], concept_id = ${p.id}
+          :rm provenance { concept_id, file_url }
+        `)
+      }
+    } catch { /* provenance relation may not exist */ }
+
+    // Delete the concept itself
     await db.run(`
       ?[id, name, type, vector, agent_id] := *concepts[id, name, type, vector, agent_id], id = ${p.id}
       :rm concepts { id, name, type, vector, agent_id }
@@ -68,7 +112,12 @@ export async function handler(params: Params, emit?: Emit): Promise<Result<Delet
     db.close()
 
     return success({
-      deleted: true
+      deleted: true,
+      cascade: {
+        edges_removed,
+        annotations_removed,
+        provenance_removed,
+      },
     })
   } catch (err) {
     db.close()

--- a/tests/graph/summary/data/00-success-basic-summary/result.json
+++ b/tests/graph/summary/data/00-success-basic-summary/result.json
@@ -1,6 +1,8 @@
 {
   "status": "success",
   "result": {
+    "total_concepts": 3,
+    "total_edges": 2,
     "concepts": {
       "total": 3,
       "by_type": {

--- a/tests/graph/summary/data/01-success-empty-graph/result.json
+++ b/tests/graph/summary/data/01-success-empty-graph/result.json
@@ -1,6 +1,8 @@
 {
   "status": "success",
   "result": {
+    "total_concepts": 0,
+    "total_edges": 0,
     "concepts": {
       "total": 0,
       "by_type": {}

--- a/tests/mind/concepts/delete/data/00-success-delete/result.json
+++ b/tests/mind/concepts/delete/data/00-success-delete/result.json
@@ -1,7 +1,12 @@
 {
   "status": "success",
   "result": {
-    "deleted": true
+    "deleted": true,
+    "cascade": {
+      "edges_removed": "<number>",
+      "annotations_removed": "<number>",
+      "provenance_removed": "<number>"
+    }
   },
   "errors": null,
   "meta": {


### PR DESCRIPTION
## Summary
- **#93** CLI error responses now return JSON envelopes via `cli_error()` helper
- **#94** Added `lens prompts` list and `--delete` flag on `lens prompt`
- **#95** Concept create detects exact name match, returns `matched_existing: true`
- **#96** Concept delete cascades to edges, annotations, provenance
- **#97** Graph summary adds flat `total_concepts`/`total_edges` aliases
- **#98** Fixed QA demo using wrong field name (`.result.valid` → `.result.passed`)

## Test plan
- [x] All 349 tc tests pass
- [ ] Run `demos/qa/run-all.sh` to verify QA demos pass

Closes #93, closes #94, closes #95, closes #96, closes #97, closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)